### PR TITLE
Expand to Atlassian enterprise MCP server (Confluence + Jira + Bitbucket)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,71 @@
+# =============================================================================
+# Atlassian Enterprise MCP Server — Environment Configuration
+# =============================================================================
+# Copy this file to .env and fill in your values.
+# Lines starting with # are comments.
+
+# =============================================================================
+# DEPLOYMENT TYPE
+# "cloud"      — Atlassian Cloud (*.atlassian.net)
+# "datacenter" — Self-hosted Atlassian Data Center / Server
+# =============================================================================
+ATLASSIAN_DEPLOYMENT=datacenter
+
+# =============================================================================
+# OPTION A: Global credentials (simplest for Atlassian Cloud)
+# These apply to all services unless overridden by service-specific vars below.
+# For Cloud: set ATLASSIAN_URL to your org URL (e.g. https://myorg.atlassian.net)
+# For Cloud auth: ATLASSIAN_USERNAME = your email, ATLASSIAN_TOKEN = your API token
+# =============================================================================
+# ATLASSIAN_URL=https://myorg.atlassian.net
+# ATLASSIAN_USERNAME=you@company.com
+# ATLASSIAN_TOKEN=your_atlassian_api_token
+
+# =============================================================================
+# OPTION B: Per-service configuration (required for Data Center, optional for Cloud)
+# Leave URL empty to disable that service entirely.
+# =============================================================================
+
+# ── Confluence ────────────────────────────────────────────────────────────────
+CONFLUENCE_URL=https://wiki.company.com
+# CONFLUENCE_TOKEN=your_confluence_pat       # Personal Access Token (preferred)
+# CONFLUENCE_USERNAME=your_username          # Basic auth (alternative)
+# CONFLUENCE_PASSWORD=your_password
+# CONFLUENCE_SSL_VERIFY=true                 # Set false to skip SSL verification
+# CONFLUENCE_CA_BUNDLE=/path/to/ca.pem       # Or path to custom CA bundle
+# CONFLUENCE_TIMEOUT=30
+# CONFLUENCE_RATE_LIMIT=5
+
+# ── Jira ─────────────────────────────────────────────────────────────────────
+JIRA_URL=https://jira.company.com
+# JIRA_TOKEN=your_jira_pat
+# JIRA_USERNAME=your_username
+# JIRA_PASSWORD=your_password
+# JIRA_SSL_VERIFY=true
+# JIRA_CA_BUNDLE=
+# JIRA_TIMEOUT=30
+# JIRA_RATE_LIMIT=5
+
+# ── Bitbucket ─────────────────────────────────────────────────────────────────
+BITBUCKET_URL=https://bitbucket.company.com
+# BITBUCKET_TOKEN=your_bitbucket_pat
+# BITBUCKET_USERNAME=your_username
+# BITBUCKET_PASSWORD=your_password
+# BITBUCKET_SSL_VERIFY=true
+# BITBUCKET_CA_BUNDLE=
+# BITBUCKET_TIMEOUT=30
+# BITBUCKET_RATE_LIMIT=5
+
+# =============================================================================
+# MCP SERVER SETTINGS
+# =============================================================================
+MCP_TRANSPORT=http      # "stdio" for Claude Desktop / Claude Code, "http" for remote
+MCP_HOST=0.0.0.0
+MCP_PORT=8000
+
+# =============================================================================
+# CONTENT & LOGGING
+# =============================================================================
+MAX_CONTENT_LENGTH=50000    # Max characters returned per page/issue
+DEFAULT_SEARCH_LIMIT=10     # Default number of search results
+LOG_LEVEL=INFO              # DEBUG, INFO, WARNING, ERROR

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir --target=/app/deps -r requirements.txt
 FROM python:3.12-slim
 
 LABEL maintainer="your-team@company.com"
-LABEL description="Confluence Server MCP Server for Claude AI"
+LABEL description="Atlassian Enterprise MCP Server for Claude AI (Confluence, Jira, Bitbucket)"
 
 # Security: run as non-root user
 RUN groupadd -r mcpuser && useradd -r -g mcpuser -d /app mcpuser
@@ -18,7 +18,8 @@ WORKDIR /app
 
 # Copy dependencies and source
 COPY --from=builder /app/deps /app/deps
-COPY config.py confluence_client.py server.py ./
+COPY config.py server.py ./
+COPY atlassian/ ./atlassian/
 
 # Add deps to Python path
 ENV PYTHONPATH=/app/deps:$PYTHONPATH

--- a/atlassian/__init__.py
+++ b/atlassian/__init__.py
@@ -1,0 +1,1 @@
+"""Atlassian MCP Server — service modules for Confluence, Jira, and Bitbucket."""

--- a/atlassian/base_client.py
+++ b/atlassian/base_client.py
@@ -1,0 +1,201 @@
+"""
+Base HTTP client for all Atlassian service clients.
+Handles authentication, rate limiting, retries, and error handling.
+"""
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger("atlassian-mcp")
+
+
+class AtlassianError(Exception):
+    """Raised when an Atlassian API call fails."""
+
+    def __init__(self, status_code: int, message: str, service: str = "atlassian"):
+        self.status_code = status_code
+        self.message = message
+        self.service = service
+        super().__init__(f"[{service}] HTTP {status_code}: {message}")
+
+
+# Backward-compatible alias
+ConfluenceError = AtlassianError
+
+
+class BaseAtlassianClient:
+    """
+    Async base client for Atlassian REST APIs.
+
+    Subclasses set self._base to their service's API root URL and define
+    service-specific convenience methods that call get/post/put.
+    """
+
+    _service_name: str = "atlassian"
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None,
+        username: str | None,
+        password: str | None,
+        ssl_verify: bool | str,
+        timeout: int,
+        rate_limit: int,
+    ):
+        self._base = base_url.rstrip("/")
+        self._timeout = timeout
+        self._semaphore = asyncio.Semaphore(rate_limit)
+        self._last_request: float = 0.0
+        self._min_interval = 1.0 / rate_limit
+
+        self._auth: httpx.BasicAuth | None = None
+        self._extra_headers: dict[str, str] = {"Accept": "application/json"}
+
+        if token:
+            self._extra_headers["Authorization"] = f"Bearer {token}"
+            logger.info("[%s] Using token authentication", self._service_name)
+        elif username and password:
+            self._auth = httpx.BasicAuth(username, password)
+            logger.info("[%s] Using Basic Auth", self._service_name)
+
+        self._verify = ssl_verify
+
+    def _build_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=httpx.Timeout(self._timeout),
+            auth=self._auth,
+            headers=self._extra_headers,
+            verify=self._verify,
+        )
+
+    async def _throttle(self) -> None:
+        async with self._semaphore:
+            now = time.monotonic()
+            wait = self._min_interval - (now - self._last_request)
+            if wait > 0:
+                await asyncio.sleep(wait)
+            self._last_request = time.monotonic()
+
+    def _raise_for_status(self, resp: httpx.Response) -> None:
+        """Raise AtlassianError for known HTTP error codes."""
+        if resp.status_code == 401:
+            raise AtlassianError(
+                401,
+                f"Authentication failed — check credentials for {self._service_name}.",
+                self._service_name,
+            )
+        if resp.status_code == 403:
+            raise AtlassianError(
+                403,
+                "Permission denied — the authenticated user lacks access to this resource.",
+                self._service_name,
+            )
+        if resp.status_code == 404:
+            raise AtlassianError(
+                404,
+                "Not found — the resource does not exist or you lack permission to view it.",
+                self._service_name,
+            )
+        if resp.status_code >= 400:
+            body = resp.text[:500]
+            raise AtlassianError(resp.status_code, body, self._service_name)
+
+    async def get(
+        self,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+        raw: bool = False,
+    ) -> dict[str, Any] | str:
+        """
+        GET request with retry on 429/503.
+        Set raw=True to return response text instead of parsed JSON.
+        """
+        url = f"{self._base}{endpoint}"
+        await self._throttle()
+
+        max_retries = 3
+        for attempt in range(max_retries):
+            async with self._build_client() as client:
+                try:
+                    resp = await client.get(url, params=params)
+                except httpx.ConnectError as exc:
+                    raise AtlassianError(
+                        0, f"Cannot connect: {exc}", self._service_name
+                    ) from exc
+                except httpx.TimeoutException as exc:
+                    raise AtlassianError(
+                        0,
+                        f"Request timed out after {self._timeout}s: {exc}",
+                        self._service_name,
+                    ) from exc
+
+                if resp.status_code in (429, 503) and attempt < max_retries - 1:
+                    delay = 2 ** (attempt + 1)
+                    logger.warning(
+                        "[%s] Rate limited (%s), retrying in %ds…",
+                        self._service_name,
+                        resp.status_code,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+
+                self._raise_for_status(resp)
+                return resp.text if raw else resp.json()
+
+        raise AtlassianError(503, "Max retries exceeded", self._service_name)
+
+    async def post(
+        self,
+        endpoint: str,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST request (no retry — write operations should not be retried automatically)."""
+        url = f"{self._base}{endpoint}"
+        await self._throttle()
+
+        async with self._build_client() as client:
+            try:
+                resp = await client.post(url, json=json_body, params=params)
+            except httpx.ConnectError as exc:
+                raise AtlassianError(0, f"Cannot connect: {exc}", self._service_name) from exc
+            except httpx.TimeoutException as exc:
+                raise AtlassianError(
+                    0, f"Request timed out after {self._timeout}s: {exc}", self._service_name
+                ) from exc
+
+            self._raise_for_status(resp)
+            if resp.status_code == 204 or not resp.content:
+                return {}
+            return resp.json()
+
+    async def put(
+        self,
+        endpoint: str,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """PUT request (no retry — write operations should not be retried automatically)."""
+        url = f"{self._base}{endpoint}"
+        await self._throttle()
+
+        async with self._build_client() as client:
+            try:
+                resp = await client.put(url, json=json_body, params=params)
+            except httpx.ConnectError as exc:
+                raise AtlassianError(0, f"Cannot connect: {exc}", self._service_name) from exc
+            except httpx.TimeoutException as exc:
+                raise AtlassianError(
+                    0, f"Request timed out after {self._timeout}s: {exc}", self._service_name
+                ) from exc
+
+            self._raise_for_status(resp)
+            if resp.status_code == 204 or not resp.content:
+                return {}
+            return resp.json()

--- a/atlassian/bitbucket/__init__.py
+++ b/atlassian/bitbucket/__init__.py
@@ -1,0 +1,1 @@
+"""Bitbucket MCP tools and API client."""

--- a/atlassian/bitbucket/client.py
+++ b/atlassian/bitbucket/client.py
@@ -1,0 +1,219 @@
+"""
+Bitbucket REST API client.
+Supports both Bitbucket Cloud (api.bitbucket.org/2.0) and Bitbucket Data Center (REST API 1.0).
+"""
+
+from typing import Any
+
+from atlassian.base_client import BaseAtlassianClient
+from config import ServiceConfig
+
+
+class BitbucketClient(BaseAtlassianClient):
+    """Async client for the Bitbucket REST API."""
+
+    _service_name = "bitbucket"
+
+    def __init__(self, service_config: ServiceConfig, deployment_type: str = "datacenter"):
+        if deployment_type == "cloud":
+            base_url = "https://api.bitbucket.org/2.0"
+        else:
+            base_url = f"{service_config.url}/rest/api/1.0"
+
+        super().__init__(
+            base_url=base_url,
+            token=service_config.token,
+            username=service_config.username,
+            password=service_config.password,
+            ssl_verify=service_config.ssl_verify,
+            timeout=service_config.timeout,
+            rate_limit=service_config.rate_limit,
+        )
+        self._deployment_type = deployment_type
+        self._service_config = service_config
+
+    @property
+    def is_cloud(self) -> bool:
+        return self._deployment_type == "cloud"
+
+    # ── Repository methods ──────────────────────────────────────
+
+    async def list_repos(
+        self, workspace_or_project: str, limit: int = 25, start: int = 0
+    ) -> dict:
+        if self.is_cloud:
+            return await self.get(
+                f"/repositories/{workspace_or_project}",
+                {"pagelen": limit, "page": (start // limit) + 1},
+            )
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos",
+            {"limit": limit, "start": start},
+        )
+
+    async def get_repo(self, workspace_or_project: str, repo_slug: str) -> dict:
+        if self.is_cloud:
+            return await self.get(f"/repositories/{workspace_or_project}/{repo_slug}")
+        return await self.get(f"/projects/{workspace_or_project}/repos/{repo_slug}")
+
+    # ── Branch methods ──────────────────────────────────────────
+
+    async def list_branches(
+        self,
+        workspace_or_project: str,
+        repo_slug: str,
+        limit: int = 25,
+        filter_text: str = "",
+    ) -> dict:
+        params: dict[str, Any] = {}
+        if self.is_cloud:
+            params["pagelen"] = limit
+            if filter_text:
+                params["q"] = f'name ~ "{filter_text}"'
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/refs/branches",
+                params,
+            )
+        params["limit"] = limit
+        if filter_text:
+            params["filterText"] = filter_text
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/branches",
+            params,
+        )
+
+    # ── Commit methods ──────────────────────────────────────────
+
+    async def get_commits(
+        self,
+        workspace_or_project: str,
+        repo_slug: str,
+        branch: str = "",
+        limit: int = 10,
+    ) -> dict:
+        params: dict[str, Any] = {}
+        if self.is_cloud:
+            params["pagelen"] = limit
+            if branch:
+                params["include"] = branch
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/commits",
+                params,
+            )
+        params["limit"] = limit
+        if branch:
+            params["until"] = branch
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/commits",
+            params,
+        )
+
+    async def get_commit(
+        self, workspace_or_project: str, repo_slug: str, commit_hash: str
+    ) -> dict:
+        if self.is_cloud:
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/commit/{commit_hash}"
+            )
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/commits/{commit_hash}"
+        )
+
+    # ── Pull request methods ─────────────────────────────────────
+
+    async def list_pull_requests(
+        self,
+        workspace_or_project: str,
+        repo_slug: str,
+        state: str = "OPEN",
+        limit: int = 10,
+    ) -> dict:
+        if self.is_cloud:
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/pullrequests",
+                {"state": state, "pagelen": limit},
+            )
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/pull-requests",
+            {"state": state, "limit": limit},
+        )
+
+    async def get_pull_request(
+        self, workspace_or_project: str, repo_slug: str, pr_id: int
+    ) -> dict:
+        if self.is_cloud:
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/pullrequests/{pr_id}"
+            )
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/pull-requests/{pr_id}"
+        )
+
+    async def create_pull_request(
+        self,
+        workspace_or_project: str,
+        repo_slug: str,
+        title: str,
+        source_branch: str,
+        dest_branch: str,
+        description: str = "",
+        reviewer_ids: list[str] | None = None,
+    ) -> dict:
+        if self.is_cloud:
+            body: dict[str, Any] = {
+                "title": title,
+                "source": {"branch": {"name": source_branch}},
+                "destination": {"branch": {"name": dest_branch}},
+            }
+            if description:
+                body["description"] = description
+            if reviewer_ids:
+                body["reviewers"] = [{"uuid": rid} for rid in reviewer_ids]
+            return await self.post(
+                f"/repositories/{workspace_or_project}/{repo_slug}/pullrequests",
+                body,
+            )
+        # Data Center
+        body = {
+            "title": title,
+            "fromRef": {"id": f"refs/heads/{source_branch}"},
+            "toRef": {"id": f"refs/heads/{dest_branch}"},
+        }
+        if description:
+            body["description"] = description
+        if reviewer_ids:
+            body["reviewers"] = [{"user": {"slug": rid}} for rid in reviewer_ids]
+        return await self.post(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/pull-requests",
+            body,
+        )
+
+    async def get_pr_diff(
+        self, workspace_or_project: str, repo_slug: str, pr_id: int
+    ) -> str:
+        if self.is_cloud:
+            return await self.get(
+                f"/repositories/{workspace_or_project}/{repo_slug}/pullrequests/{pr_id}/diff",
+                raw=True,
+            )
+        return await self.get(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/pull-requests/{pr_id}/diff",
+            raw=True,
+        )
+
+    async def add_pr_comment(
+        self,
+        workspace_or_project: str,
+        repo_slug: str,
+        pr_id: int,
+        text: str,
+    ) -> dict:
+        if self.is_cloud:
+            return await self.post(
+                f"/repositories/{workspace_or_project}/{repo_slug}/pullrequests/{pr_id}/comments",
+                {"content": {"raw": text}},
+            )
+        return await self.post(
+            f"/projects/{workspace_or_project}/repos/{repo_slug}/pull-requests/{pr_id}/comments",
+            {"text": text},
+        )

--- a/atlassian/bitbucket/tools.py
+++ b/atlassian/bitbucket/tools.py
@@ -1,0 +1,398 @@
+"""
+Bitbucket MCP tool definitions.
+Call register_tools(mcp, client, config) to add all Bitbucket tools to a FastMCP instance.
+"""
+
+import logging
+
+from atlassian.base_client import AtlassianError
+from atlassian.bitbucket.client import BitbucketClient
+from atlassian.shared.formatters import truncate
+from config import AtlassianConfig
+
+logger = logging.getLogger("atlassian-mcp.bitbucket")
+
+
+def _error(err: AtlassianError) -> str:
+    return f"Bitbucket API error (HTTP {err.status_code}): {err.message}"
+
+
+def _format_commit(commit: dict, is_cloud: bool) -> str:
+    if is_cloud:
+        sha = commit.get("hash", "?")[:8]
+        msg = commit.get("message", "").split("\n")[0]
+        author = commit.get("author", {}).get("user", {}).get("display_name", "")
+        if not author:
+            author = commit.get("author", {}).get("raw", "?")
+        date = (commit.get("date") or "")[:10]
+    else:
+        sha = commit.get("id", "?")[:8]
+        msg = commit.get("message", "").split("\n")[0]
+        author_obj = commit.get("author") or {}
+        author = author_obj.get("name", author_obj.get("emailAddress", "?"))
+        ts = commit.get("authorTimestamp", 0)
+        date = ""
+        if ts:
+            import datetime
+            date = datetime.datetime.fromtimestamp(ts / 1000, tz=datetime.timezone.utc).strftime(
+                "%Y-%m-%d"
+            )
+    return f"`{sha}` {msg} — {author}{f' ({date})' if date else ''}"
+
+
+def _format_pr(pr: dict, is_cloud: bool) -> str:
+    if is_cloud:
+        pr_id = pr.get("id", "?")
+        title = pr.get("title", "?")
+        state = pr.get("state", "?")
+        author = pr.get("author", {}).get("display_name", "?")
+        src = pr.get("source", {}).get("branch", {}).get("name", "?")
+        dst = pr.get("destination", {}).get("branch", {}).get("name", "?")
+        updated = (pr.get("updated_on") or "")[:10]
+    else:
+        pr_id = pr.get("id", "?")
+        title = pr.get("title", "?")
+        state = pr.get("state", "?")
+        author = pr.get("author", {}).get("displayName", "?")
+        src = pr.get("fromRef", {}).get("displayId", "?")
+        dst = pr.get("toRef", {}).get("displayId", "?")
+        updated = ""
+        ts = pr.get("updatedDate", 0)
+        if ts:
+            import datetime
+            updated = datetime.datetime.fromtimestamp(
+                ts / 1000, tz=datetime.timezone.utc
+            ).strftime("%Y-%m-%d")
+
+    line = f"PR #{pr_id}: **{title}** [{state}]"
+    line += f"\n   {src} → {dst} | Author: {author}"
+    if updated:
+        line += f" | Updated: {updated}"
+    return line
+
+
+def register_tools(mcp, client: BitbucketClient, config: AtlassianConfig) -> None:
+    """Register all Bitbucket tools onto the FastMCP instance."""
+
+    is_cloud = client.is_cloud
+
+    @mcp.tool()
+    async def bitbucket_list_repos(workspace: str, limit: int = 25) -> str:
+        """List repositories in a Bitbucket workspace (Cloud) or project (Data Center).
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center), e.g. 'myteam' or 'PROJ'.
+            limit: Maximum repositories to return (default 25).
+        """
+        try:
+            data = await client.list_repos(workspace, limit=min(limit, 100))
+        except AtlassianError as e:
+            return _error(e)
+
+        repos = data.get("values", [])
+        if not repos:
+            return f"No repositories found in '{workspace}'."
+
+        total = data.get("size") or data.get("total") or len(repos)
+        lines = [f"## Repositories in '{workspace}' ({total} total — showing {len(repos)})\n"]
+        for r in repos:
+            if is_cloud:
+                slug = r.get("slug", "?")
+                name = r.get("full_name", slug)
+                desc = (r.get("description") or "").strip()
+                lang = r.get("language", "")
+                updated = (r.get("updated_on") or "")[:10]
+            else:
+                slug = r.get("slug", "?")
+                name = r.get("name", slug)
+                desc = (r.get("description") or "").strip()
+                lang = ""
+                updated = ""
+
+            entry = f"- **{name}** (`{slug}`)"
+            if lang:
+                entry += f" [{lang}]"
+            if updated:
+                entry += f" — updated {updated}"
+            if desc:
+                entry += f"\n  {desc[:100]}"
+            lines.append(entry)
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_get_repo(workspace: str, repo_slug: str) -> str:
+        """Get details for a specific Bitbucket repository.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug (e.g. 'my-repo').
+        """
+        try:
+            repo = await client.get_repo(workspace, repo_slug)
+        except AtlassianError as e:
+            return _error(e)
+
+        if is_cloud:
+            name = repo.get("full_name", repo_slug)
+            desc = (repo.get("description") or "").strip()
+            lang = repo.get("language", "")
+            created = (repo.get("created_on") or "")[:10]
+            updated = (repo.get("updated_on") or "")[:10]
+            clone_links = repo.get("links", {}).get("clone", [])
+            clone_url = next(
+                (c.get("href") for c in clone_links if c.get("name") == "https"), ""
+            )
+            size = repo.get("size", 0)
+        else:
+            name = repo.get("name", repo_slug)
+            desc = (repo.get("description") or "").strip()
+            lang = ""
+            created = updated = ""
+            clone_links = repo.get("links", {}).get("clone", [])
+            clone_url = next(
+                (c.get("href") for c in clone_links if c.get("name") == "http"), ""
+            )
+            size = 0
+
+        lines = [f"## {name}"]
+        if desc:
+            lines.append(desc)
+        if lang:
+            lines.append(f"Language: {lang}")
+        if created:
+            lines.append(f"Created: {created} | Updated: {updated}")
+        if size:
+            lines.append(f"Size: {size:,} bytes")
+        if clone_url:
+            lines.append(f"Clone: {clone_url}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_list_branches(
+        workspace: str, repo_slug: str, limit: int = 25, filter: str = ""
+    ) -> str:
+        """List branches in a Bitbucket repository.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            limit: Maximum branches to return (default 25).
+            filter: Filter branches by name substring.
+        """
+        try:
+            data = await client.list_branches(workspace, repo_slug, limit=min(limit, 100), filter_text=filter)
+        except AtlassianError as e:
+            return _error(e)
+
+        branches = data.get("values", [])
+        if not branches:
+            return f"No branches found in '{workspace}/{repo_slug}'."
+
+        lines = [f"## Branches in {workspace}/{repo_slug} ({len(branches)} shown)\n"]
+        for b in branches:
+            if is_cloud:
+                name = b.get("name", "?")
+                sha = (b.get("target") or {}).get("hash", "?")[:8]
+            else:
+                name = b.get("displayId", b.get("id", "?"))
+                sha = (b.get("latestCommit") or "?")[:8]
+            lines.append(f"- `{name}` — latest commit: {sha}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_get_commits(
+        workspace: str, repo_slug: str, branch: str = "", limit: int = 10
+    ) -> str:
+        """Get recent commits in a Bitbucket repository.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            branch: Branch name to filter commits (leave empty for default branch).
+            limit: Maximum commits to return (default 10).
+        """
+        try:
+            data = await client.get_commits(workspace, repo_slug, branch=branch, limit=min(limit, 50))
+        except AtlassianError as e:
+            return _error(e)
+
+        commits = data.get("values", [])
+        if not commits:
+            return "No commits found."
+
+        scope = f" on `{branch}`" if branch else ""
+        lines = [f"## Recent Commits in {workspace}/{repo_slug}{scope}\n"]
+        for c in commits:
+            lines.append(f"- {_format_commit(c, is_cloud)}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_get_commit(workspace: str, repo_slug: str, commit_hash: str) -> str:
+        """Get details for a specific commit.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            commit_hash: Full or abbreviated commit hash.
+        """
+        try:
+            commit = await client.get_commit(workspace, repo_slug, commit_hash)
+        except AtlassianError as e:
+            return _error(e)
+
+        return f"## Commit {commit_hash[:8]}\n{_format_commit(commit, is_cloud)}"
+
+    @mcp.tool()
+    async def bitbucket_list_pull_requests(
+        workspace: str,
+        repo_slug: str,
+        state: str = "OPEN",
+        limit: int = 10,
+    ) -> str:
+        """List pull requests in a Bitbucket repository.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            state: PR state filter — 'OPEN', 'MERGED', 'DECLINED' (or 'ALL' for Data Center).
+            limit: Maximum PRs to return (default 10).
+        """
+        try:
+            data = await client.list_pull_requests(workspace, repo_slug, state=state, limit=min(limit, 50))
+        except AtlassianError as e:
+            return _error(e)
+
+        prs = data.get("values", [])
+        if not prs:
+            return f"No {state.lower()} pull requests in {workspace}/{repo_slug}."
+
+        total = data.get("size") or data.get("totalCount") or len(prs)
+        lines = [f"## {state} Pull Requests in {workspace}/{repo_slug} ({total} total)\n"]
+        for i, pr in enumerate(prs, 1):
+            lines.append(f"{i}. {_format_pr(pr, is_cloud)}")
+
+        return "\n\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_get_pull_request(
+        workspace: str, repo_slug: str, pr_id: int
+    ) -> str:
+        """Get full details of a Bitbucket pull request.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            pr_id: The pull request ID number.
+        """
+        try:
+            pr = await client.get_pull_request(workspace, repo_slug, pr_id)
+        except AtlassianError as e:
+            return _error(e)
+
+        lines = [_format_pr(pr, is_cloud)]
+
+        if is_cloud:
+            desc = (pr.get("description") or "").strip()
+            reviewers = pr.get("reviewers", [])
+        else:
+            desc = (pr.get("description") or "").strip()
+            reviewers = pr.get("reviewers", [])
+
+        if desc:
+            lines.append(f"\n## Description\n{desc}")
+
+        if reviewers:
+            if is_cloud:
+                names = [r.get("display_name", "?") for r in reviewers]
+            else:
+                names = [r.get("user", {}).get("displayName", "?") for r in reviewers]
+            lines.append(f"\nReviewers: {', '.join(names)}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def bitbucket_create_pull_request(
+        workspace: str,
+        repo_slug: str,
+        title: str,
+        source_branch: str,
+        destination_branch: str,
+        description: str = "",
+        reviewer_ids: str = "",
+    ) -> str:
+        """Create a new Bitbucket pull request.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            title: Pull request title.
+            source_branch: The branch with your changes.
+            destination_branch: The branch to merge into (e.g. 'main', 'master', 'develop').
+            description: Optional PR description.
+            reviewer_ids: Comma-separated reviewer UUIDs (Cloud) or usernames (Data Center).
+        """
+        reviewer_list = [r.strip() for r in reviewer_ids.split(",") if r.strip()] if reviewer_ids else None
+        try:
+            result = await client.create_pull_request(
+                workspace_or_project=workspace,
+                repo_slug=repo_slug,
+                title=title,
+                source_branch=source_branch,
+                dest_branch=destination_branch,
+                description=description,
+                reviewer_ids=reviewer_list,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        pr_id = result.get("id", "?")
+        pr_title = result.get("title", title)
+        if is_cloud:
+            pr_url = result.get("links", {}).get("html", {}).get("href", "")
+        else:
+            pr_url = (result.get("links", {}).get("self") or [{}])[0].get("href", "")
+
+        out = f"Pull request created: **PR #{pr_id}** — {pr_title}\n{source_branch} → {destination_branch}"
+        if pr_url:
+            out += f"\nURL: {pr_url}"
+        return out
+
+    @mcp.tool()
+    async def bitbucket_get_pr_diff(workspace: str, repo_slug: str, pr_id: int) -> str:
+        """Get the unified diff for a Bitbucket pull request.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            pr_id: The pull request ID number.
+        """
+        try:
+            diff_text = await client.get_pr_diff(workspace, repo_slug, pr_id)
+        except AtlassianError as e:
+            return _error(e)
+
+        return truncate(str(diff_text), config.max_content_length)
+
+    @mcp.tool()
+    async def bitbucket_add_pr_comment(
+        workspace: str, repo_slug: str, pr_id: int, comment: str
+    ) -> str:
+        """Add a comment to a Bitbucket pull request.
+
+        Args:
+            workspace: Workspace slug (Cloud) or project key (Data Center).
+            repo_slug: Repository slug.
+            pr_id: The pull request ID number.
+            comment: The comment text.
+        """
+        try:
+            result = await client.add_pr_comment(workspace, repo_slug, pr_id, comment)
+        except AtlassianError as e:
+            return _error(e)
+
+        comment_id = result.get("id", "?")
+        return f"Comment added to PR #{pr_id} (comment ID: {comment_id})."

--- a/atlassian/confluence/__init__.py
+++ b/atlassian/confluence/__init__.py
@@ -1,0 +1,1 @@
+"""Confluence MCP tools and API client."""

--- a/atlassian/confluence/client.py
+++ b/atlassian/confluence/client.py
@@ -1,0 +1,70 @@
+"""
+Confluence REST API client.
+Supports both Atlassian Cloud (/wiki/rest/api) and Data Center (/rest/api).
+"""
+
+from typing import Any
+
+from atlassian.base_client import BaseAtlassianClient
+from config import ServiceConfig
+
+
+class ConfluenceClient(BaseAtlassianClient):
+    """Async client for the Confluence REST API."""
+
+    _service_name = "confluence"
+
+    def __init__(self, service_config: ServiceConfig, deployment_type: str = "datacenter"):
+        # Cloud Confluence lives under /wiki; Data Center does not
+        if deployment_type == "cloud":
+            base_url = f"{service_config.url}/wiki/rest/api"
+        else:
+            base_url = f"{service_config.url}/rest/api"
+
+        super().__init__(
+            base_url=base_url,
+            token=service_config.token,
+            username=service_config.username,
+            password=service_config.password,
+            ssl_verify=service_config.ssl_verify,
+            timeout=service_config.timeout,
+            rate_limit=service_config.rate_limit,
+        )
+        self._service_config = service_config
+        self._base_url_root = service_config.url
+
+    # ── Convenience methods ─────────────────────────────────────
+
+    async def get_page(self, page_id: str, expand: str) -> dict:
+        return await self.get(f"/content/{page_id}", {"expand": expand})
+
+    async def get_page_by_title(self, space_key: str, title: str, expand: str) -> dict:
+        return await self.get(
+            "/content",
+            {"spaceKey": space_key, "title": title, "expand": expand, "limit": 1},
+        )
+
+    async def search(self, cql: str, limit: int, expand: str) -> dict:
+        return await self.get(
+            "/content/search",
+            {"cql": cql, "limit": limit, "expand": expand},
+        )
+
+    async def list_spaces(
+        self, space_type: str | None, limit: int, expand: str
+    ) -> dict:
+        params: dict[str, Any] = {"limit": limit, "expand": expand}
+        if space_type and space_type != "all":
+            params["type"] = space_type
+        return await self.get("/space", params)
+
+    async def get_child(
+        self, page_id: str, child_type: str, expand: str, limit: int
+    ) -> dict:
+        return await self.get(
+            f"/content/{page_id}/child/{child_type}",
+            {"expand": expand, "limit": limit},
+        )
+
+    async def get_labels(self, page_id: str) -> dict:
+        return await self.get(f"/content/{page_id}/label")

--- a/atlassian/confluence/tools.py
+++ b/atlassian/confluence/tools.py
@@ -1,0 +1,361 @@
+"""
+Confluence MCP tool definitions.
+Call register_tools(mcp, client, config) to add all Confluence tools to a FastMCP instance.
+"""
+
+import logging
+from typing import Literal
+
+from atlassian.base_client import AtlassianError
+from atlassian.confluence.client import ConfluenceClient
+from atlassian.shared.formatters import strip_html, truncate
+from atlassian.shared.url_utils import parse_confluence_url
+from config import AtlassianConfig
+
+logger = logging.getLogger("atlassian-mcp.confluence")
+
+
+def _format_labels(page: dict) -> str:
+    labels = page.get("metadata", {}).get("labels", {}).get("results", [])
+    return ", ".join(lb["name"] for lb in labels) if labels else ""
+
+
+def _page_url(page: dict, base_url: str) -> str:
+    links = page.get("_links", {})
+    base = links.get("base", base_url)
+    webui = links.get("webui", "")
+    return f"{base}{webui}" if webui else ""
+
+
+def _error(err: AtlassianError) -> str:
+    return f"Confluence API error (HTTP {err.status_code}): {err.message}"
+
+
+def register_tools(mcp, client: ConfluenceClient, config: AtlassianConfig) -> None:
+    """Register all Confluence tools onto the FastMCP instance."""
+
+    base_url = config.confluence.url
+
+    @mcp.tool()
+    async def confluence_search(cql: str, limit: int = 10) -> str:
+        """Search Confluence pages using CQL (Confluence Query Language).
+
+        Use this to find pages across all spaces by keyword, label, author, or date.
+
+        Args:
+            cql: A CQL query string. Examples:
+                 - 'type=page AND text~"deployment guide"'
+                 - 'type=page AND space=DEV AND text~"API"'
+                 - 'type=page AND label="architecture"'
+                 - 'type=page AND lastmodified > now("-7d") ORDER BY lastmodified DESC'
+                 - 'title~"release notes" AND space IN (DEV, OPS)'
+            limit: Maximum results to return (1–50, default 10).
+        """
+        try:
+            data = await client.search(
+                cql=cql,
+                limit=min(max(limit, 1), 50),
+                expand="space,version,metadata.labels",
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        results = data.get("results", [])
+        if not results:
+            return "No results found. Try broadening your CQL or check the space key."
+
+        total = data.get("totalSize", len(results))
+        lines = [f"Found {total} result(s) — showing {len(results)}:\n"]
+
+        for i, page in enumerate(results, 1):
+            sk = page.get("space", {}).get("key", "?")
+            version = page.get("version", {}).get("number", "?")
+            labels = _format_labels(page)
+            url = _page_url(page, base_url)
+
+            entry = (
+                f"{i}. **{page['title']}**\n"
+                f"   ID: {page['id']} | Space: {sk} | v{version}"
+            )
+            if labels:
+                entry += f" | Labels: {labels}"
+            if url:
+                entry += f"\n   URL: {url}"
+            lines.append(entry)
+
+        return "\n\n".join(lines)
+
+    @mcp.tool()
+    async def confluence_get_page(
+        page_id: str,
+        format: Literal["storage", "view"] = "storage",
+        include_body: bool = True,
+    ) -> str:
+        """Retrieve a Confluence page's full content by its numeric ID.
+
+        Args:
+            page_id: The numeric page ID (e.g. '3965072').
+            format: Body format — 'storage' (raw XHTML) or 'view' (rendered HTML).
+            include_body: Set False to fetch only metadata.
+        """
+        expand_parts = ["version", "space", "metadata.labels", "ancestors"]
+        if include_body:
+            expand_parts.append(f"body.{format}")
+
+        try:
+            page = await client.get_page(page_id, expand=",".join(expand_parts))
+        except AtlassianError as e:
+            return _error(e)
+
+        space_name = page.get("space", {}).get("name", "")
+        space_key = page.get("space", {}).get("key", "")
+        version = page.get("version", {}).get("number", "")
+        labels = _format_labels(page)
+        ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
+        url = _page_url(page, base_url)
+
+        header = f"# {page['title']}\n"
+        header += f"Space: {space_name} ({space_key}) | Version: {version}\n"
+        if labels:
+            header += f"Labels: {labels}\n"
+        if ancestors:
+            header += f"Path: {ancestors} → {page['title']}\n"
+        if url:
+            header += f"URL: {url}\n"
+
+        if not include_body:
+            return header
+
+        raw_body = page.get("body", {}).get(format, {}).get("value", "")
+        body = strip_html(raw_body) if format == "view" else raw_body
+        return f"{header}\n---\n\n{truncate(body, config.max_content_length)}"
+
+    @mcp.tool()
+    async def confluence_get_page_by_url(
+        url: str,
+        format: Literal["storage", "view"] = "storage",
+    ) -> str:
+        """Retrieve a Confluence page by its full URL.
+
+        Use this when a user pastes a Confluence link. Supports all URL formats:
+        /pages/viewpage.action?pageId=123, /display/SPACE/Title,
+        /spaces/SPACE/pages/123/Title, etc.
+
+        Args:
+            url: Any Confluence page URL (full or relative path).
+            format: Body format — 'storage' (raw XHTML) or 'view' (rendered HTML).
+        """
+        parsed = parse_confluence_url(url)
+        page_id = parsed.get("page_id")
+        space_key = parsed.get("space_key")
+        title = parsed.get("title")
+
+        if not page_id and not (space_key and title):
+            return (
+                f"Could not parse the Confluence URL: {url}\n\n"
+                "Supported formats:\n"
+                "  - http://confluence/pages/viewpage.action?pageId=12345\n"
+                "  - http://confluence/display/SPACEKEY/Page+Title\n"
+                "  - http://confluence/spaces/SPACEKEY/pages/12345/Title\n\n"
+                "Try using confluence_get_page(page_id) or "
+                "confluence_get_page_by_title(space_key, title) directly."
+            )
+
+        if page_id and page_id.startswith("tinyurl:"):
+            return (
+                "Tiny URLs (/x/...) need server-side resolution.\n"
+                "Open the link in a browser first to get the full URL, then paste that instead."
+            )
+
+        expand = f"body.{format},version,space,metadata.labels,ancestors"
+
+        try:
+            if page_id:
+                page = await client.get_page(page_id, expand=expand)
+            else:
+                data = await client.get_page_by_title(
+                    space_key=space_key, title=title, expand=expand
+                )
+                results = data.get("results", [])
+                if not results:
+                    return (
+                        f"No page titled '{title}' found in space {space_key}.\n"
+                        f'Tip: Try confluence_search with: title~"{title}" AND space={space_key}'
+                    )
+                page = results[0]
+        except AtlassianError as e:
+            return _error(e)
+
+        space_name = page.get("space", {}).get("name", "")
+        sk = page.get("space", {}).get("key", "")
+        version = page.get("version", {}).get("number", "")
+        labels = _format_labels(page)
+        ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
+        page_url = _page_url(page, base_url)
+
+        header = f"# {page['title']}\n"
+        header += f"ID: {page['id']} | Space: {space_name} ({sk}) | Version: {version}\n"
+        if labels:
+            header += f"Labels: {labels}\n"
+        if ancestors:
+            header += f"Path: {ancestors} → {page['title']}\n"
+        if page_url:
+            header += f"URL: {page_url}\n"
+
+        raw_body = page.get("body", {}).get(format, {}).get("value", "")
+        body = strip_html(raw_body) if format == "view" else raw_body
+        return f"{header}\n---\n\n{truncate(body, config.max_content_length)}"
+
+    @mcp.tool()
+    async def confluence_get_page_by_title(space_key: str, title: str) -> str:
+        """Find a Confluence page by its exact title within a space.
+
+        Args:
+            space_key: The space key (e.g. 'DEV', 'TEAM', 'HR').
+            title: The exact page title to look for.
+        """
+        try:
+            data = await client.get_page_by_title(
+                space_key=space_key,
+                title=title,
+                expand="body.storage,version,space,metadata.labels,ancestors",
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        results = data.get("results", [])
+        if not results:
+            return (
+                f"No page titled '{title}' found in space {space_key}.\n"
+                "Tip: titles are case-sensitive and must be exact. "
+                f'Try confluence_search with: title~"{title}" AND space={space_key}'
+            )
+
+        page = results[0]
+        space_name = page.get("space", {}).get("name", "")
+        version = page.get("version", {}).get("number", "")
+        labels = _format_labels(page)
+        ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
+        url = _page_url(page, base_url)
+        raw_body = page.get("body", {}).get("storage", {}).get("value", "")
+
+        header = f"# {page['title']}\n"
+        header += f"ID: {page['id']} | Space: {space_name} ({space_key}) | Version: {version}\n"
+        if labels:
+            header += f"Labels: {labels}\n"
+        if ancestors:
+            header += f"Path: {ancestors} → {page['title']}\n"
+        if url:
+            header += f"URL: {url}\n"
+
+        return f"{header}\n---\n\n{truncate(raw_body, config.max_content_length)}"
+
+    @mcp.tool()
+    async def confluence_list_spaces(
+        type: Literal["global", "personal", "all"] = "global",
+        limit: int = 50,
+    ) -> str:
+        """List Confluence spaces the authenticated user can access.
+
+        Args:
+            type: Filter by space type — 'global', 'personal', or 'all'.
+            limit: Maximum spaces to return (default 50).
+        """
+        try:
+            data = await client.list_spaces(
+                space_type=type if type != "all" else None,
+                limit=limit,
+                expand="description.plain",
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        spaces = data.get("results", [])
+        if not spaces:
+            return "No spaces found."
+
+        lines = [f"## Confluence Spaces ({len(spaces)} found)\n"]
+        for s in spaces:
+            desc = s.get("description", {}).get("plain", {}).get("value", "").strip()
+            desc_preview = (desc[:80] + "…") if len(desc) > 80 else desc
+            entry = f"- **{s['name']}** — key: `{s['key']}` ({s.get('type', '?')})"
+            if desc_preview:
+                entry += f"\n  {desc_preview}"
+            lines.append(entry)
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def confluence_get_comments(page_id: str, limit: int = 25) -> str:
+        """Get comments on a Confluence page (inline and footer comments).
+
+        Args:
+            page_id: The numeric page ID.
+            limit: Maximum comments to return (default 25).
+        """
+        try:
+            data = await client.get_child(
+                page_id=page_id,
+                child_type="comment",
+                expand="body.view,version,extensions.inlineProperties",
+                limit=limit,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        comments = data.get("results", [])
+        if not comments:
+            return "No comments on this page."
+
+        lines = [f"## Comments ({len(comments)})\n"]
+        for c in comments:
+            author = c.get("version", {}).get("by", {}).get("displayName", "Unknown")
+            when = c.get("version", {}).get("when", "")
+            location = c.get("extensions", {}).get("location", "footer")
+            raw_body = c.get("body", {}).get("view", {}).get("value", "")
+            body = strip_html(raw_body)
+
+            entry = f"**{author}** ({location})"
+            if when:
+                entry += f" — {when}"
+            entry += f"\n{body}"
+            lines.append(entry)
+
+        return "\n\n---\n\n".join(lines)
+
+    @mcp.tool()
+    async def confluence_get_attachments(page_id: str, limit: int = 50) -> str:
+        """List file attachments on a Confluence page with download URLs.
+
+        Args:
+            page_id: The numeric page ID.
+            limit: Maximum attachments to return (default 50).
+        """
+        try:
+            data = await client.get_child(
+                page_id=page_id,
+                child_type="attachment",
+                expand="version",
+                limit=limit,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        atts = data.get("results", [])
+        if not atts:
+            return "No attachments on this page."
+
+        lines = [f"## Attachments ({len(atts)})\n"]
+        for a in atts:
+            media_type = a.get("metadata", {}).get("mediaType", "unknown")
+            download = a.get("_links", {}).get("download", "")
+            full_url = f"{base_url}{download}" if download else "N/A"
+            version = a.get("version", {}).get("number", "?")
+
+            lines.append(
+                f"- **{a['title']}**\n"
+                f"  Type: {media_type} | Version: {version}\n"
+                f"  Download: {full_url}"
+            )
+
+        return "\n".join(lines)

--- a/atlassian/jira/__init__.py
+++ b/atlassian/jira/__init__.py
@@ -1,0 +1,1 @@
+"""Jira MCP tools and API client."""

--- a/atlassian/jira/client.py
+++ b/atlassian/jira/client.py
@@ -1,0 +1,159 @@
+"""
+Jira REST API client.
+Supports both Atlassian Cloud (/rest/api/3) and Data Center (/rest/api/2).
+"""
+
+from typing import Any
+
+from atlassian.base_client import BaseAtlassianClient
+from config import ServiceConfig
+
+
+class JiraClient(BaseAtlassianClient):
+    """Async client for the Jira REST API."""
+
+    _service_name = "jira"
+
+    def __init__(self, service_config: ServiceConfig, deployment_type: str = "datacenter"):
+        # Cloud uses API v3 (ADF); Data Center uses v2 (plain text)
+        api_version = "3" if deployment_type == "cloud" else "2"
+        base_url = f"{service_config.url}/rest/api/{api_version}"
+
+        super().__init__(
+            base_url=base_url,
+            token=service_config.token,
+            username=service_config.username,
+            password=service_config.password,
+            ssl_verify=service_config.ssl_verify,
+            timeout=service_config.timeout,
+            rate_limit=service_config.rate_limit,
+        )
+        self._deployment_type = deployment_type
+        self._service_config = service_config
+
+    @property
+    def is_cloud(self) -> bool:
+        return self._deployment_type == "cloud"
+
+    def _description_body(self, text: str) -> dict | str:
+        """Return description payload in the correct format for this deployment."""
+        if self.is_cloud:
+            # Atlassian Document Format (ADF)
+            return {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": text}],
+                    }
+                ],
+            }
+        return text
+
+    # ── Issue methods ───────────────────────────────────────────
+
+    async def get_issue(self, issue_key: str, expand: str = "") -> dict:
+        params: dict[str, Any] = {}
+        if expand:
+            params["expand"] = expand
+        return await self.get(f"/issue/{issue_key}", params or None)
+
+    async def search_issues(
+        self,
+        jql: str,
+        limit: int = 10,
+        fields: str = "summary,status,assignee,priority,updated,issuetype",
+        start_at: int = 0,
+    ) -> dict:
+        return await self.get(
+            "/search",
+            {"jql": jql, "maxResults": limit, "fields": fields, "startAt": start_at},
+        )
+
+    async def create_issue(
+        self,
+        project_key: str,
+        summary: str,
+        issue_type: str,
+        description: str = "",
+        priority: str = "",
+        labels: list[str] | None = None,
+        assignee_id: str = "",
+    ) -> dict:
+        fields: dict[str, Any] = {
+            "project": {"key": project_key},
+            "summary": summary,
+            "issuetype": {"name": issue_type},
+        }
+        if description:
+            fields["description"] = self._description_body(description)
+        if priority:
+            fields["priority"] = {"name": priority}
+        if labels:
+            fields["labels"] = labels
+        if assignee_id:
+            key = "accountId" if self.is_cloud else "name"
+            fields["assignee"] = {key: assignee_id}
+
+        return await self.post("/issue", {"fields": fields})
+
+    async def update_issue(
+        self,
+        issue_key: str,
+        summary: str = "",
+        description: str = "",
+        priority: str = "",
+        labels: list[str] | None = None,
+    ) -> dict:
+        fields: dict[str, Any] = {}
+        if summary:
+            fields["summary"] = summary
+        if description:
+            fields["description"] = self._description_body(description)
+        if priority:
+            fields["priority"] = {"name": priority}
+        if labels is not None:
+            fields["labels"] = labels
+
+        return await self.put(f"/issue/{issue_key}", {"fields": fields})
+
+    async def get_transitions(self, issue_key: str) -> dict:
+        return await self.get(f"/issue/{issue_key}/transitions")
+
+    async def transition_issue(self, issue_key: str, transition_id: str) -> dict:
+        return await self.post(
+            f"/issue/{issue_key}/transitions",
+            {"transition": {"id": transition_id}},
+        )
+
+    async def add_comment(self, issue_key: str, body: str) -> dict:
+        comment_body = self._description_body(body) if self.is_cloud else body
+        return await self.post(
+            f"/issue/{issue_key}/comment",
+            {"body": comment_body},
+        )
+
+    async def get_comments(self, issue_key: str, limit: int = 25) -> dict:
+        return await self.get(
+            f"/issue/{issue_key}/comment",
+            {"maxResults": limit},
+        )
+
+    async def assign_issue(self, issue_key: str, assignee_id: str) -> dict:
+        key = "accountId" if self.is_cloud else "name"
+        return await self.put(
+            f"/issue/{issue_key}/assignee",
+            {key: assignee_id},
+        )
+
+    # ── Project methods ─────────────────────────────────────────
+
+    async def list_projects(self, limit: int = 50, start_at: int = 0) -> dict:
+        return await self.get(
+            "/project/search",
+            {"maxResults": limit, "startAt": start_at},
+        )
+
+    async def get_project(self, project_key: str) -> dict:
+        return await self.get(f"/project/{project_key}", {"expand": "issueTypes"})

--- a/atlassian/jira/tools.py
+++ b/atlassian/jira/tools.py
@@ -1,0 +1,442 @@
+"""
+Jira MCP tool definitions.
+Call register_tools(mcp, client, config) to add all Jira tools to a FastMCP instance.
+"""
+
+import logging
+
+from atlassian.base_client import AtlassianError
+from atlassian.jira.client import JiraClient
+from atlassian.shared.formatters import adf_to_text, truncate
+from config import AtlassianConfig
+
+logger = logging.getLogger("atlassian-mcp.jira")
+
+
+def _error(err: AtlassianError) -> str:
+    return f"Jira API error (HTTP {err.status_code}): {err.message}"
+
+
+def _format_issue_summary(issue: dict) -> str:
+    """Format a single issue into a compact summary line."""
+    key = issue.get("key", "?")
+    fields = issue.get("fields", {})
+    summary = fields.get("summary", "")
+    status = fields.get("status", {}).get("name", "?")
+    assignee = (fields.get("assignee") or {}).get("displayName", "Unassigned")
+    priority = (fields.get("priority") or {}).get("name", "?")
+    issue_type = (fields.get("issuetype") or {}).get("name", "?")
+    updated = fields.get("updated", "")[:10]  # YYYY-MM-DD
+
+    line = f"**{key}** [{issue_type}] {summary}"
+    line += f"\n   Status: {status} | Priority: {priority} | Assignee: {assignee}"
+    if updated:
+        line += f" | Updated: {updated}"
+    return line
+
+
+def _format_issue_detail(issue: dict) -> str:
+    """Format a single issue with full details."""
+    key = issue.get("key", "?")
+    fields = issue.get("fields", {})
+
+    summary = fields.get("summary", "")
+    status = fields.get("status", {}).get("name", "?")
+    issue_type = (fields.get("issuetype") or {}).get("name", "?")
+    priority = (fields.get("priority") or {}).get("name", "?")
+    assignee = (fields.get("assignee") or {}).get("displayName", "Unassigned")
+    reporter = (fields.get("reporter") or {}).get("displayName", "Unknown")
+    created = (fields.get("created") or "")[:10]
+    updated = (fields.get("updated") or "")[:10]
+    labels = ", ".join(fields.get("labels") or [])
+    components = ", ".join(c.get("name", "") for c in (fields.get("components") or []))
+    fix_versions = ", ".join(v.get("name", "") for v in (fields.get("fixVersions") or []))
+
+    # Description — handle both ADF (Cloud v3) and plain text (DC v2)
+    raw_desc = fields.get("description") or ""
+    if isinstance(raw_desc, dict):
+        description = adf_to_text(raw_desc).strip()
+    else:
+        description = str(raw_desc).strip()
+
+    lines = [
+        f"# [{key}] {summary}",
+        f"Type: {issue_type} | Status: {status} | Priority: {priority}",
+        f"Assignee: {assignee} | Reporter: {reporter}",
+        f"Created: {created} | Updated: {updated}",
+    ]
+    if labels:
+        lines.append(f"Labels: {labels}")
+    if components:
+        lines.append(f"Components: {components}")
+    if fix_versions:
+        lines.append(f"Fix Versions: {fix_versions}")
+
+    if description:
+        lines.append(f"\n## Description\n{description}")
+
+    # Linked issues
+    links = fields.get("issuelinks") or []
+    if links:
+        link_lines = []
+        for lnk in links:
+            if "outwardIssue" in lnk:
+                rel = lnk.get("type", {}).get("outward", "relates to")
+                linked_key = lnk["outwardIssue"].get("key", "?")
+                linked_summary = lnk["outwardIssue"].get("fields", {}).get("summary", "")
+                link_lines.append(f"  - {rel}: {linked_key} — {linked_summary}")
+            elif "inwardIssue" in lnk:
+                rel = lnk.get("type", {}).get("inward", "is related to")
+                linked_key = lnk["inwardIssue"].get("key", "?")
+                linked_summary = lnk["inwardIssue"].get("fields", {}).get("summary", "")
+                link_lines.append(f"  - {rel}: {linked_key} — {linked_summary}")
+        if link_lines:
+            lines.append("\n## Linked Issues\n" + "\n".join(link_lines))
+
+    return "\n".join(lines)
+
+
+def register_tools(mcp, client: JiraClient, config: AtlassianConfig) -> None:
+    """Register all Jira tools onto the FastMCP instance."""
+
+    @mcp.tool()
+    async def jira_get_issue(issue_key: str) -> str:
+        """Retrieve full details of a Jira issue by its key.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123', 'BUG-42').
+        """
+        try:
+            issue = await client.get_issue(
+                issue_key,
+                expand="names,renderedFields,transitions,issuelinks",
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        return truncate(_format_issue_detail(issue), config.max_content_length)
+
+    @mcp.tool()
+    async def jira_search_issues(
+        jql: str,
+        limit: int = 10,
+        fields: str = "summary,status,assignee,priority,updated,issuetype",
+    ) -> str:
+        """Search Jira issues using JQL (Jira Query Language).
+
+        Args:
+            jql: A JQL query string. Examples:
+                 - 'project = PROJ AND status = "In Progress"'
+                 - 'assignee = currentUser() AND status != Done ORDER BY updated DESC'
+                 - 'priority = High AND created >= -7d'
+                 - 'text ~ "login error" AND project IN (APP, API)'
+                 - 'sprint in openSprints() AND assignee = jsmith'
+                 - 'labels = "backend" AND fixVersion = "2.0"'
+            limit: Maximum results to return (1–50, default 10).
+            fields: Comma-separated fields to include in results.
+        """
+        try:
+            data = await client.search_issues(
+                jql=jql,
+                limit=min(max(limit, 1), 50),
+                fields=fields,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        issues = data.get("issues", [])
+        if not issues:
+            return "No issues found for that JQL query. Try broadening the search or checking the project key."
+
+        total = data.get("total", len(issues))
+        lines = [f"Found {total} issue(s) — showing {len(issues)}:\n"]
+        for i, issue in enumerate(issues, 1):
+            lines.append(f"{i}. {_format_issue_summary(issue)}")
+
+        return "\n\n".join(lines)
+
+    @mcp.tool()
+    async def jira_get_my_issues(limit: int = 10) -> str:
+        """List Jira issues currently assigned to you, ordered by most recently updated.
+
+        Args:
+            limit: Maximum issues to return (default 10).
+        """
+        jql = "assignee = currentUser() AND status != Done ORDER BY updated DESC"
+        try:
+            data = await client.search_issues(jql=jql, limit=min(limit, 50))
+        except AtlassianError as e:
+            return _error(e)
+
+        issues = data.get("issues", [])
+        if not issues:
+            return "No open issues assigned to you."
+
+        lines = [f"## Your Open Issues ({len(issues)})\n"]
+        for i, issue in enumerate(issues, 1):
+            lines.append(f"{i}. {_format_issue_summary(issue)}")
+
+        return "\n\n".join(lines)
+
+    @mcp.tool()
+    async def jira_create_issue(
+        project_key: str,
+        summary: str,
+        issue_type: str = "Task",
+        description: str = "",
+        priority: str = "",
+        labels: str = "",
+        assignee_id: str = "",
+    ) -> str:
+        """Create a new Jira issue.
+
+        Args:
+            project_key: The project key (e.g. 'PROJ', 'BUG').
+            summary: Short title for the issue.
+            issue_type: Issue type name (e.g. 'Task', 'Bug', 'Story', 'Epic').
+            description: Detailed description (plain text).
+            priority: Priority name (e.g. 'High', 'Medium', 'Low').
+            labels: Comma-separated list of labels (e.g. 'backend,api').
+            assignee_id: Assignee account ID (Cloud) or username (Data Center).
+        """
+        label_list = [l.strip() for l in labels.split(",") if l.strip()] if labels else None
+        try:
+            result = await client.create_issue(
+                project_key=project_key,
+                summary=summary,
+                issue_type=issue_type,
+                description=description,
+                priority=priority,
+                labels=label_list,
+                assignee_id=assignee_id,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        issue_key = result.get("key", "?")
+        issue_id = result.get("id", "?")
+        return f"Issue created: **{issue_key}** (ID: {issue_id})\nSummary: {summary}"
+
+    @mcp.tool()
+    async def jira_update_issue(
+        issue_key: str,
+        summary: str = "",
+        description: str = "",
+        priority: str = "",
+        labels: str = "",
+    ) -> str:
+        """Update fields on an existing Jira issue.
+
+        Only the fields you provide will be changed. Pass an empty string to skip a field.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            summary: New summary/title (leave empty to keep unchanged).
+            description: New description text (leave empty to keep unchanged).
+            priority: New priority name (e.g. 'High', 'Medium', 'Low').
+            labels: Comma-separated labels. Replaces all existing labels if provided.
+        """
+        if not any([summary, description, priority, labels]):
+            return "No fields to update — provide at least one of: summary, description, priority, labels."
+
+        label_list = [l.strip() for l in labels.split(",") if l.strip()] if labels else None
+        try:
+            await client.update_issue(
+                issue_key=issue_key,
+                summary=summary,
+                description=description,
+                priority=priority,
+                labels=label_list,
+            )
+        except AtlassianError as e:
+            return _error(e)
+
+        updated = []
+        if summary:
+            updated.append(f"summary → '{summary}'")
+        if description:
+            updated.append("description updated")
+        if priority:
+            updated.append(f"priority → '{priority}'")
+        if label_list is not None:
+            updated.append(f"labels → {label_list}")
+        return f"Updated {issue_key}: {', '.join(updated)}"
+
+    @mcp.tool()
+    async def jira_get_transitions(issue_key: str) -> str:
+        """List the valid status transitions for a Jira issue.
+
+        Use this before calling jira_transition_issue to get the correct transition ID.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+        """
+        try:
+            data = await client.get_transitions(issue_key)
+        except AtlassianError as e:
+            return _error(e)
+
+        transitions = data.get("transitions", [])
+        if not transitions:
+            return f"No transitions available for {issue_key}."
+
+        lines = [f"## Available Transitions for {issue_key}\n"]
+        for t in transitions:
+            tid = t.get("id", "?")
+            name = t.get("name", "?")
+            to_status = t.get("to", {}).get("name", "?")
+            lines.append(f"- ID: `{tid}` — **{name}** → {to_status}")
+
+        lines.append(
+            "\nUse jira_transition_issue(issue_key, transition_id) "
+            "with one of the IDs above."
+        )
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def jira_transition_issue(issue_key: str, transition_id: str) -> str:
+        """Move a Jira issue to a new status using a transition.
+
+        First call jira_get_transitions(issue_key) to get the valid transition IDs.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            transition_id: The transition ID from jira_get_transitions.
+        """
+        try:
+            await client.transition_issue(issue_key, transition_id)
+        except AtlassianError as e:
+            return _error(e)
+
+        return f"Successfully transitioned {issue_key} using transition {transition_id}."
+
+    @mcp.tool()
+    async def jira_add_comment(issue_key: str, body: str) -> str:
+        """Add a comment to a Jira issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            body: The comment text (plain text).
+        """
+        try:
+            result = await client.add_comment(issue_key, body)
+        except AtlassianError as e:
+            return _error(e)
+
+        comment_id = result.get("id", "?")
+        author = (result.get("author") or result.get("updateAuthor") or {}).get(
+            "displayName", "You"
+        )
+        return f"Comment added to {issue_key} by {author} (comment ID: {comment_id})."
+
+    @mcp.tool()
+    async def jira_get_comments(issue_key: str, limit: int = 25) -> str:
+        """Get comments on a Jira issue.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            limit: Maximum comments to return (default 25).
+        """
+        try:
+            data = await client.get_comments(issue_key, limit=limit)
+        except AtlassianError as e:
+            return _error(e)
+
+        comments = data.get("comments", [])
+        if not comments:
+            return f"No comments on {issue_key}."
+
+        total = data.get("total", len(comments))
+        lines = [f"## Comments on {issue_key} ({total} total)\n"]
+        for c in comments:
+            author = (c.get("author") or {}).get("displayName", "Unknown")
+            created = (c.get("created") or "")[:10]
+            raw_body = c.get("body", "")
+            if isinstance(raw_body, dict):
+                body = adf_to_text(raw_body).strip()
+            else:
+                body = str(raw_body).strip()
+
+            entry = f"**{author}** — {created}\n{body}"
+            lines.append(entry)
+
+        return "\n\n---\n\n".join(lines)
+
+    @mcp.tool()
+    async def jira_list_projects(limit: int = 50) -> str:
+        """List Jira projects accessible to the authenticated user.
+
+        Args:
+            limit: Maximum projects to return (default 50).
+        """
+        try:
+            data = await client.list_projects(limit=min(limit, 100))
+        except AtlassianError as e:
+            return _error(e)
+
+        projects = data.get("values", [])
+        if not projects:
+            return "No projects found."
+
+        total = data.get("total", len(projects))
+        lines = [f"## Jira Projects ({total} total — showing {len(projects)})\n"]
+        for p in projects:
+            key = p.get("key", "?")
+            name = p.get("name", "?")
+            ptype = p.get("projectTypeKey", "?")
+            lead = (p.get("lead") or {}).get("displayName", "")
+            entry = f"- **{key}** — {name} ({ptype})"
+            if lead:
+                entry += f" | Lead: {lead}"
+            lines.append(entry)
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def jira_get_project(project_key: str) -> str:
+        """Get details and issue types for a Jira project.
+
+        Args:
+            project_key: The project key (e.g. 'PROJ').
+        """
+        try:
+            project = await client.get_project(project_key)
+        except AtlassianError as e:
+            return _error(e)
+
+        name = project.get("name", "?")
+        description = (project.get("description") or "").strip()
+        lead = (project.get("lead") or {}).get("displayName", "Unknown")
+        ptype = project.get("projectTypeKey", "?")
+
+        issue_types = project.get("issueTypes", [])
+        type_names = [it.get("name", "") for it in issue_types if it.get("name")]
+
+        lines = [
+            f"## Project: {name} ({project_key})",
+            f"Type: {ptype} | Lead: {lead}",
+        ]
+        if description:
+            lines.append(f"Description: {description}")
+        if type_names:
+            lines.append(f"\nIssue Types: {', '.join(type_names)}")
+
+        return "\n".join(lines)
+
+    @mcp.tool()
+    async def jira_assign_issue(issue_key: str, assignee_id: str) -> str:
+        """Assign a Jira issue to a user.
+
+        Args:
+            issue_key: The issue key (e.g. 'PROJ-123').
+            assignee_id: Account ID (Cloud) or username (Data Center).
+                         Use empty string to unassign.
+        """
+        try:
+            await client.assign_issue(issue_key, assignee_id)
+        except AtlassianError as e:
+            return _error(e)
+
+        if assignee_id:
+            return f"Assigned {issue_key} to '{assignee_id}'."
+        return f"Unassigned {issue_key}."

--- a/atlassian/shared/__init__.py
+++ b/atlassian/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for all Atlassian service modules."""

--- a/atlassian/shared/formatters.py
+++ b/atlassian/shared/formatters.py
@@ -1,0 +1,58 @@
+"""
+Shared text formatting utilities for all Atlassian service modules.
+"""
+
+import re
+
+
+def strip_html(html: str) -> str:
+    """Lightweight HTML tag stripper for readable output."""
+    text = re.sub(r"<br\s*/?>", "\n", html)
+    text = re.sub(r"</(p|div|h[1-6]|li|tr)>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"&nbsp;", " ", text)
+    text = re.sub(r"&amp;", "&", text)
+    text = re.sub(r"&lt;", "<", text)
+    text = re.sub(r"&gt;", ">", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def truncate(text: str, max_len: int = 50000) -> str:
+    """Truncate text to max_len characters with an indicator."""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + f"\n\n... [truncated — {len(text)} chars total]"
+
+
+def adf_to_text(adf: dict) -> str:
+    """Convert Atlassian Document Format (ADF) to plain text (best-effort)."""
+    if not isinstance(adf, dict):
+        return str(adf)
+
+    node_type = adf.get("type", "")
+    content = adf.get("content", [])
+    text_val = adf.get("text", "")
+
+    if node_type == "text":
+        return text_val
+
+    parts = [adf_to_text(child) for child in content]
+
+    if node_type in ("paragraph", "heading"):
+        return " ".join(p for p in parts if p) + "\n"
+    if node_type == "bulletList":
+        return "\n".join(f"• {p.strip()}" for p in parts if p.strip())
+    if node_type == "orderedList":
+        return "\n".join(f"{i + 1}. {p.strip()}" for i, p in enumerate(parts) if p.strip())
+    if node_type == "listItem":
+        return " ".join(p for p in parts if p)
+    if node_type == "hardBreak":
+        return "\n"
+    if node_type == "codeBlock":
+        code = "".join(parts)
+        return f"```\n{code}\n```"
+    if node_type == "blockquote":
+        return "\n".join(f"> {p}" for p in parts if p)
+
+    return " ".join(p for p in parts if p)

--- a/atlassian/shared/url_utils.py
+++ b/atlassian/shared/url_utils.py
@@ -1,0 +1,77 @@
+"""
+Confluence URL parsing utilities.
+"""
+
+import re
+from urllib.parse import urlparse, parse_qs, unquote
+
+
+def parse_confluence_url(url: str) -> dict[str, str | None]:
+    """
+    Parse any Confluence URL and extract page_id, space_key, and title.
+
+    Supported URL formats:
+      1. /pages/viewpage.action?pageId=12345
+      2. /display/SPACEKEY/Page+Title
+      3. /display/SPACEKEY/Page+Title?src=...
+      4. /spaces/SPACEKEY/pages/12345/Page+Title   (newer Data Center)
+      5. /x/shortlink                               (tiny URLs)
+      6. /pages/12345                               (direct ID)
+      7. /wiki/display/SPACEKEY/Page+Title          (with /wiki context)
+      8. /confluence/display/SPACEKEY/Page+Title     (with /confluence context)
+    """
+    parsed = urlparse(url.strip())
+    path = parsed.path
+    query = parse_qs(parsed.query)
+
+    result: dict[str, str | None] = {
+        "page_id": None,
+        "space_key": None,
+        "title": None,
+    }
+
+    # Format 1: ?pageId=12345
+    if "pageId" in query:
+        result["page_id"] = query["pageId"][0]
+        return result
+
+    # Strip common context prefixes (/wiki, /confluence, etc.)
+    for prefix in ["/wiki", "/confluence"]:
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+
+    # Format 2/3: /display/SPACEKEY/Page+Title
+    display_match = re.match(r"/display/([^/]+)/(.+?)(?:\?.*)?$", path)
+    if display_match:
+        result["space_key"] = display_match.group(1)
+        result["title"] = unquote(display_match.group(2).replace("+", " "))
+        return result
+
+    # Format 4: /spaces/SPACEKEY/pages/12345/Page+Title
+    spaces_match = re.match(r"/spaces/([^/]+)/pages/(\d+)(?:/(.+))?", path)
+    if spaces_match:
+        result["space_key"] = spaces_match.group(1)
+        result["page_id"] = spaces_match.group(2)
+        if spaces_match.group(3):
+            result["title"] = unquote(spaces_match.group(3).replace("+", " "))
+        return result
+
+    # Format 5: /x/shortlink (tiny URL — need to resolve via API)
+    tiny_match = re.match(r"/x/([A-Za-z0-9_-]+)", path)
+    if tiny_match:
+        result["page_id"] = f"tinyurl:{tiny_match.group(1)}"
+        return result
+
+    # Format 6: /pages/12345
+    pages_match = re.match(r"/pages/(\d+)", path)
+    if pages_match:
+        result["page_id"] = pages_match.group(1)
+        return result
+
+    # Fallback: if the path contains a numeric segment, try that as page ID
+    num_match = re.search(r"/(\d{4,})", path)
+    if num_match:
+        result["page_id"] = num_match.group(1)
+        return result
+
+    return result

--- a/config.py
+++ b/config.py
@@ -1,6 +1,11 @@
 """
-Configuration loader for Confluence MCP Server.
-Reads from .env file and validates required settings.
+Configuration loader for the Atlassian Enterprise MCP Server.
+Supports Confluence, Jira, and Bitbucket with both Cloud and Data Center deployments.
+
+Environment variable priority for each service:
+  1. Service-specific vars  (CONFLUENCE_URL, JIRA_URL, BITBUCKET_URL)
+  2. Global fallback vars   (ATLASSIAN_URL, ATLASSIAN_USERNAME, ATLASSIAN_TOKEN)
+  3. Empty string           (service disabled)
 """
 
 import os
@@ -13,7 +18,6 @@ from dotenv import load_dotenv
 
 def _find_env_file() -> Path | None:
     """Search for .env file in current dir, parent dirs, and script dir."""
-    # In frozen (PyInstaller) mode, env vars come from Claude Desktop — skip .env
     if getattr(sys, "frozen", False):
         return None
     candidates = [
@@ -27,20 +31,49 @@ def _find_env_file() -> Path | None:
     return None
 
 
-@dataclass(frozen=True)
-class Config:
-    """Immutable server configuration."""
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() not in ("false", "0", "no")
 
-    # Confluence
-    confluence_url: str
+
+def _ssl_verify(ssl_raw: str, ca_bundle: str) -> bool | str:
+    if ca_bundle:
+        return ca_bundle
+    return _parse_bool(ssl_raw)
+
+
+@dataclass(frozen=True)
+class ServiceConfig:
+    """Configuration for a single Atlassian service."""
+
+    url: str
+    token: str | None
     username: str | None
     password: str | None
-    token: str | None
-    ssl_verify: bool | str  # bool or path to CA bundle
+    ssl_verify: bool | str
     timeout: int
     rate_limit: int
+    enabled: bool
 
-    # MCP Server
+    @property
+    def auth_method(self) -> str:
+        if self.token:
+            return "token"
+        if self.username and self.password:
+            return "basic"
+        return "none"
+
+
+@dataclass(frozen=True)
+class AtlassianConfig:
+    """Immutable top-level configuration for the Atlassian MCP Server."""
+
+    deployment_type: str  # "cloud" or "datacenter"
+
+    confluence: ServiceConfig
+    jira: ServiceConfig
+    bitbucket: ServiceConfig
+
+    # MCP server
     transport: str
     host: str
     port: int
@@ -52,50 +85,131 @@ class Config:
     # Logging
     log_level: str
 
-    @property
-    def auth_method(self) -> str:
-        if self.token:
-            return "token"
-        if self.username and self.password:
-            return "basic"
-        return "none"
-
     def validate(self) -> list[str]:
-        """Return list of validation errors (empty = valid)."""
+        """Return validation errors (empty = valid)."""
         errors = []
-        if not self.confluence_url:
-            errors.append("CONFLUENCE_URL is required")
-        if not self.token and not (self.username and self.password):
+
+        if self.deployment_type not in ("cloud", "datacenter"):
             errors.append(
-                "Either CONFLUENCE_TOKEN or both CONFLUENCE_USERNAME "
-                "and CONFLUENCE_PASSWORD must be set"
+                f"ATLASSIAN_DEPLOYMENT must be 'cloud' or 'datacenter', "
+                f"got '{self.deployment_type}'"
             )
+
         if self.transport not in ("stdio", "http"):
-            errors.append(f"MCP_TRANSPORT must be 'stdio' or 'http', got '{self.transport}'")
+            errors.append(
+                f"MCP_TRANSPORT must be 'stdio' or 'http', got '{self.transport}'"
+            )
+
+        # At least one service must be configured
+        active = [s for s in (self.confluence, self.jira, self.bitbucket) if s.enabled]
+        if not active:
+            errors.append(
+                "No services are configured. Set at least one of: "
+                "CONFLUENCE_URL, JIRA_URL, BITBUCKET_URL (or ATLASSIAN_URL)"
+            )
+
+        # Validate each enabled service has credentials
+        for name, svc in [("Confluence", self.confluence), ("Jira", self.jira), ("Bitbucket", self.bitbucket)]:
+            if not svc.enabled:
+                continue
+            if not svc.token and not (svc.username and svc.password):
+                errors.append(
+                    f"{name}: Either *_TOKEN or both *_USERNAME and *_PASSWORD must be set"
+                )
+
         return errors
 
 
-def load_config() -> Config:
-    """Load configuration from environment / .env file."""
+# ---------------------------------------------------------------------------
+# Backward-compatible alias — existing code that imports `Config` still works
+# ---------------------------------------------------------------------------
+Config = AtlassianConfig
+
+
+def _build_service_config(
+    *,
+    url: str,
+    token: str | None,
+    username: str | None,
+    password: str | None,
+    ssl_raw: str,
+    ca_bundle: str,
+    timeout: int,
+    rate_limit: int,
+) -> ServiceConfig:
+    return ServiceConfig(
+        url=url.rstrip("/"),
+        token=token or None,
+        username=username or None,
+        password=password or None,
+        ssl_verify=_ssl_verify(ssl_raw, ca_bundle),
+        timeout=timeout,
+        rate_limit=rate_limit,
+        enabled=bool(url),
+    )
+
+
+def load_config() -> AtlassianConfig:
+    """Load and validate configuration from environment / .env file."""
     env_path = _find_env_file()
     if env_path:
         load_dotenv(env_path, override=False)
 
-    ssl_verify_raw = os.getenv("CONFLUENCE_SSL_VERIFY", "true").strip()
-    ca_bundle = os.getenv("CONFLUENCE_CA_BUNDLE", "").strip()
-    if ca_bundle:
-        ssl_verify: bool | str = ca_bundle
-    else:
-        ssl_verify = ssl_verify_raw.lower() not in ("false", "0", "no")
+    # Global Atlassian fallbacks (useful for Cloud where one credential set covers all services)
+    global_url = os.getenv("ATLASSIAN_URL", "").rstrip("/")
+    global_token = os.getenv("ATLASSIAN_TOKEN", "")
+    global_username = os.getenv("ATLASSIAN_USERNAME", "")
+    global_password = os.getenv("ATLASSIAN_PASSWORD", "")
+    global_ssl_raw = os.getenv("ATLASSIAN_SSL_VERIFY", "true")
+    global_ca_bundle = os.getenv("ATLASSIAN_CA_BUNDLE", "").strip()
+    global_timeout = int(os.getenv("ATLASSIAN_TIMEOUT", "30"))
+    global_rate_limit = int(os.getenv("ATLASSIAN_RATE_LIMIT", "5"))
 
-    config = Config(
-        confluence_url=os.getenv("CONFLUENCE_URL", "").rstrip("/"),
-        username=os.getenv("CONFLUENCE_USERNAME"),
-        password=os.getenv("CONFLUENCE_PASSWORD"),
-        token=os.getenv("CONFLUENCE_TOKEN"),
-        ssl_verify=ssl_verify,
-        timeout=int(os.getenv("CONFLUENCE_TIMEOUT", "30")),
-        rate_limit=int(os.getenv("CONFLUENCE_RATE_LIMIT", "5")),
+    deployment_type = os.getenv("ATLASSIAN_DEPLOYMENT", "datacenter").lower()
+
+    # ── Confluence ──────────────────────────────────────────────────────────
+    # Cloud Confluence uses /wiki prefix; datacenter does not
+    raw_conf_url = os.getenv("CONFLUENCE_URL", global_url)
+    confluence = _build_service_config(
+        url=raw_conf_url,
+        token=os.getenv("CONFLUENCE_TOKEN", global_token),
+        username=os.getenv("CONFLUENCE_USERNAME", global_username),
+        password=os.getenv("CONFLUENCE_PASSWORD", global_password),
+        ssl_raw=os.getenv("CONFLUENCE_SSL_VERIFY", global_ssl_raw),
+        ca_bundle=os.getenv("CONFLUENCE_CA_BUNDLE", global_ca_bundle),
+        timeout=int(os.getenv("CONFLUENCE_TIMEOUT", str(global_timeout))),
+        rate_limit=int(os.getenv("CONFLUENCE_RATE_LIMIT", str(global_rate_limit))),
+    )
+
+    # ── Jira ────────────────────────────────────────────────────────────────
+    jira = _build_service_config(
+        url=os.getenv("JIRA_URL", global_url),
+        token=os.getenv("JIRA_TOKEN", global_token),
+        username=os.getenv("JIRA_USERNAME", global_username),
+        password=os.getenv("JIRA_PASSWORD", global_password),
+        ssl_raw=os.getenv("JIRA_SSL_VERIFY", global_ssl_raw),
+        ca_bundle=os.getenv("JIRA_CA_BUNDLE", global_ca_bundle),
+        timeout=int(os.getenv("JIRA_TIMEOUT", str(global_timeout))),
+        rate_limit=int(os.getenv("JIRA_RATE_LIMIT", str(global_rate_limit))),
+    )
+
+    # ── Bitbucket ───────────────────────────────────────────────────────────
+    bitbucket = _build_service_config(
+        url=os.getenv("BITBUCKET_URL", global_url),
+        token=os.getenv("BITBUCKET_TOKEN", global_token),
+        username=os.getenv("BITBUCKET_USERNAME", global_username),
+        password=os.getenv("BITBUCKET_PASSWORD", global_password),
+        ssl_raw=os.getenv("BITBUCKET_SSL_VERIFY", global_ssl_raw),
+        ca_bundle=os.getenv("BITBUCKET_CA_BUNDLE", global_ca_bundle),
+        timeout=int(os.getenv("BITBUCKET_TIMEOUT", str(global_timeout))),
+        rate_limit=int(os.getenv("BITBUCKET_RATE_LIMIT", str(global_rate_limit))),
+    )
+
+    config = AtlassianConfig(
+        deployment_type=deployment_type,
+        confluence=confluence,
+        jira=jira,
+        bitbucket=bitbucket,
         transport=os.getenv("MCP_TRANSPORT", "http").lower(),
         host=os.getenv("MCP_HOST", "0.0.0.0"),
         port=int(os.getenv("MCP_PORT", "8000")),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@
 # Quick start: cp .env.example .env && edit .env && docker compose up -d
 
 services:
-  confluence-mcp:
+  atlassian-mcp:
     build: .
-    container_name: confluence-mcp-server
+    container_name: atlassian-mcp-server
     restart: unless-stopped
     ports:
       - "${MCP_PORT:-8000}:8000"
@@ -27,7 +27,7 @@ services:
       retries: 3
       start_period: 10s
 
-# Optional: if your Confluence is on a Docker network
+# Optional: if your Atlassian services are on a Docker network
 # networks:
 #   corporate-net:
 #     external: true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+respx>=0.21.0

--- a/server.py
+++ b/server.py
@@ -1,17 +1,12 @@
 """
-Confluence Server MCP Server
-=============================
-An MCP (Model Context Protocol) server that connects Claude to your
-self-hosted Confluence Server / Data Center instance.
+Atlassian Enterprise MCP Server
+================================
+A unified MCP (Model Context Protocol) server that connects Claude to Atlassian tools:
+  - Confluence — search pages, read content, list spaces, comments, attachments
+  - Jira        — search issues, create/update issues, manage transitions, comments
+  - Bitbucket   — list repos/branches/commits, manage pull requests
 
-Tools provided:
-  - search_confluence   — CQL-powered search across all spaces
-  - get_page            — Fetch full page content by ID
-  - get_page_by_url     — Fetch page content by pasting any Confluence URL
-  - get_page_by_title   — Find a page by exact title in a space
-  - list_spaces         — List all accessible Confluence spaces
-  - get_comments        — Get comments on a page
-  - get_attachments     — List file attachments on a page
+Supports both Atlassian Cloud and self-hosted Data Center / Server deployments.
 
 Usage:
   # stdio mode (Claude Desktop / Claude Code)
@@ -22,523 +17,83 @@ Usage:
 """
 
 import logging
-import re
 import sys
-from typing import Literal
-from urllib.parse import urlparse, parse_qs, unquote
 
 from mcp.server.fastmcp import FastMCP
 
-from config import Config, load_config
-from confluence_client import ConfluenceClient, ConfluenceError
+from config import load_config
 
 # ── Bootstrap ───────────────────────────────────────────────────
 
-config: Config = load_config()
+config = load_config()
 
 logging.basicConfig(
     level=getattr(logging, config.log_level, logging.INFO),
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     stream=sys.stderr,  # CRITICAL: never log to stdout in stdio mode
 )
-logger = logging.getLogger("confluence-mcp")
+logger = logging.getLogger("atlassian-mcp")
 
 mcp = FastMCP(
-    "confluence-server",
+    "atlassian-server",
     instructions=(
-        "Confluence Server integration. Use these tools to search wiki pages, "
-        "read page content, list spaces, and fetch comments/attachments from "
-        "a self-hosted Confluence instance. "
-        "When a user pastes a Confluence URL, always use get_page_by_url to "
-        "fetch the page content directly from the link."
+        "Atlassian Enterprise integration. Tools available for:\n"
+        "- Confluence: search wiki pages, read content, list spaces, fetch comments and attachments\n"
+        "- Jira: search and manage issues, projects, transitions, and comments\n"
+        "- Bitbucket: list repositories, branches, commits, and manage pull requests\n\n"
+        "When a user pastes a Confluence URL, use confluence_get_page_by_url. "
+        "When searching Jira, use JQL syntax with jira_search_issues. "
+        "Use tool names prefixed with the service (confluence_*, jira_*, bitbucket_*)."
     ),
 )
 
-client = ConfluenceClient(config)
-
-
-# ── Helpers ─────────────────────────────────────────────────────
-
-def _strip_html(html: str) -> str:
-    """Lightweight HTML tag stripper for readable output."""
-    text = re.sub(r"<br\s*/?>", "\n", html)
-    text = re.sub(r"</(p|div|h[1-6]|li|tr)>", "\n", text)
-    text = re.sub(r"<[^>]+>", "", text)
-    text = re.sub(r"&nbsp;", " ", text)
-    text = re.sub(r"&amp;", "&", text)
-    text = re.sub(r"&lt;", "<", text)
-    text = re.sub(r"&gt;", ">", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
-
-
-def _truncate(text: str, max_len: int | None = None) -> str:
-    limit = max_len or config.max_content_length
-    if len(text) <= limit:
-        return text
-    return text[:limit] + f"\n\n... [truncated — {len(text)} chars total]"
-
-
-def _format_labels(page: dict) -> str:
-    labels = (
-        page.get("metadata", {})
-        .get("labels", {})
-        .get("results", [])
-    )
-    return ", ".join(lb["name"] for lb in labels) if labels else ""
-
-
-def _page_url(page: dict) -> str:
-    links = page.get("_links", {})
-    base = links.get("base", config.confluence_url)
-    webui = links.get("webui", "")
-    return f"{base}{webui}" if webui else ""
-
-
-def _error_response(err: ConfluenceError) -> str:
-    """Format a ConfluenceError into a user-friendly message."""
-    return f"❌ Confluence API error (HTTP {err.status_code}): {err.message}"
-
-
-def _parse_confluence_url(url: str) -> dict[str, str | None]:
-    """
-    Parse any Confluence URL and extract page_id, space_key, and title.
-
-    Supported URL formats:
-      1. /pages/viewpage.action?pageId=12345
-      2. /display/SPACEKEY/Page+Title
-      3. /display/SPACEKEY/Page+Title?src=...
-      4. /spaces/SPACEKEY/pages/12345/Page+Title   (newer Data Center)
-      5. /x/shortlink                               (tiny URLs)
-      6. /pages/12345                               (direct ID)
-      7. /wiki/display/SPACEKEY/Page+Title          (with /wiki context)
-      8. /confluence/display/SPACEKEY/Page+Title     (with /confluence context)
-    """
-    parsed = urlparse(url.strip())
-    path = parsed.path
-    query = parse_qs(parsed.query)
-
-    result: dict[str, str | None] = {
-        "page_id": None,
-        "space_key": None,
-        "title": None,
-    }
-
-    # Format 1: ?pageId=12345
-    if "pageId" in query:
-        result["page_id"] = query["pageId"][0]
-        return result
-
-    # Strip common context prefixes (/wiki, /confluence, etc.)
-    for prefix in ["/wiki", "/confluence"]:
-        if path.startswith(prefix):
-            path = path[len(prefix):]
-
-    # Format 2/3: /display/SPACEKEY/Page+Title
-    display_match = re.match(r"/display/([^/]+)/(.+?)(?:\?.*)?$", path)
-    if display_match:
-        result["space_key"] = display_match.group(1)
-        result["title"] = unquote(display_match.group(2).replace("+", " "))
-        return result
-
-    # Format 4: /spaces/SPACEKEY/pages/12345/Page+Title
-    spaces_match = re.match(r"/spaces/([^/]+)/pages/(\d+)(?:/(.+))?", path)
-    if spaces_match:
-        result["space_key"] = spaces_match.group(1)
-        result["page_id"] = spaces_match.group(2)
-        if spaces_match.group(3):
-            result["title"] = unquote(spaces_match.group(3).replace("+", " "))
-        return result
-
-    # Format 5: /x/shortlink (tiny URL — need to resolve via API)
-    tiny_match = re.match(r"/x/([A-Za-z0-9_-]+)", path)
-    if tiny_match:
-        # Tiny links can't be resolved locally; return marker
-        result["page_id"] = f"tinyurl:{tiny_match.group(1)}"
-        return result
-
-    # Format 6: /pages/12345
-    pages_match = re.match(r"/pages/(\d+)", path)
-    if pages_match:
-        result["page_id"] = pages_match.group(1)
-        return result
-
-    # Fallback: if the path contains a numeric segment, try that as page ID
-    num_match = re.search(r"/(\d{4,})", path)
-    if num_match:
-        result["page_id"] = num_match.group(1)
-        return result
-
-    return result
-
-
-# ── MCP Tools ───────────────────────────────────────────────────
-
-@mcp.tool()
-async def get_page_by_url(
-    url: str,
-    format: Literal["storage", "view"] = "storage",
-) -> str:
-    """Retrieve a Confluence page by its full URL.
-
-    Use this when a user pastes a Confluence link. Supports all URL formats:
-    /pages/viewpage.action?pageId=123, /display/SPACE/Title, /spaces/SPACE/pages/123/Title, etc.
-
-    Args:
-        url: Any Confluence page URL (full or relative path).
-        format: Body format — 'storage' (raw XHTML) or 'view' (rendered HTML).
-    """
-    parsed = _parse_confluence_url(url)
-
-    page_id = parsed.get("page_id")
-    space_key = parsed.get("space_key")
-    title = parsed.get("title")
-
-    # If we couldn't parse anything useful
-    if not page_id and not (space_key and title):
-        return (
-            f"❌ Could not parse the Confluence URL: {url}\n\n"
-            f"Supported formats:\n"
-            f"  - http://confluence/pages/viewpage.action?pageId=12345\n"
-            f"  - http://confluence/display/SPACEKEY/Page+Title\n"
-            f"  - http://confluence/spaces/SPACEKEY/pages/12345/Title\n\n"
-            f"Try using get_page(page_id) or get_page_by_title(space_key, title) directly."
-        )
-
-    # If we have a tiny URL, we can't resolve it locally — try fetching via ID
-    if page_id and page_id.startswith("tinyurl:"):
-        return (
-            f"❌ Tiny URLs (/x/...) need server-side resolution.\n"
-            f"Try opening the link in a browser first to get the full URL, "
-            f"then paste that instead."
-        )
-
-    expand = f"body.{format},version,space,metadata.labels,ancestors"
-
-    try:
-        if page_id:
-            page = await client.get_page(page_id, expand=expand)
-        else:
-            # Lookup by space + title
-            data = await client.get_page_by_title(
-                space_key=space_key, title=title, expand=expand
-            )
-            results = data.get("results", [])
-            if not results:
-                return (
-                    f"No page titled '{title}' found in space {space_key}.\n"
-                    f"Tip: Try search_confluence with: title~\"{title}\" AND space={space_key}"
-                )
-            page = results[0]
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    # Format output (same as get_page)
-    space_name = page.get("space", {}).get("name", "")
-    sk = page.get("space", {}).get("key", "")
-    version = page.get("version", {}).get("number", "")
-    labels = _format_labels(page)
-    ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
-    page_url = _page_url(page)
-
-    header = f"# {page['title']}\n"
-    header += f"ID: {page['id']} | Space: {space_name} ({sk}) | Version: {version}\n"
-    if labels:
-        header += f"Labels: {labels}\n"
-    if ancestors:
-        header += f"Path: {ancestors} → {page['title']}\n"
-    if page_url:
-        header += f"URL: {page_url}\n"
-
-    raw_body = page.get("body", {}).get(format, {}).get("value", "")
-    body = _strip_html(raw_body) if format == "view" else raw_body
-    body = _truncate(body)
-
-    return f"{header}\n---\n\n{body}"
-
-@mcp.tool()
-async def search_confluence(
-    cql: str,
-    limit: int = 10,
-) -> str:
-    """Search Confluence pages using CQL (Confluence Query Language).
-
-    Use this to find pages across all spaces by keyword, label, author, or date.
-
-    Args:
-        cql: A CQL query string. Examples:
-             - 'type=page AND text~"deployment guide"'
-             - 'type=page AND space=DEV AND text~"API"'
-             - 'type=page AND label="architecture"'
-             - 'type=page AND lastmodified > now("-7d") ORDER BY lastmodified DESC'
-             - 'title~"release notes" AND space IN (DEV, OPS)'
-             - 'creator=jsmith AND type=page'
-        limit: Maximum results to return (1–50, default 10).
-    """
-    try:
-        data = await client.search(
-            cql=cql,
-            limit=min(max(limit, 1), 50),
-            expand="space,version,metadata.labels",
-        )
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    results = data.get("results", [])
-    if not results:
-        return "No results found for that query. Try broadening your CQL or check the space key."
-
-    total = data.get("totalSize", len(results))
-    lines = [f"Found {total} result(s) — showing {len(results)}:\n"]
-
-    for i, page in enumerate(results, 1):
-        space_key = page.get("space", {}).get("key", "?")
-        version = page.get("version", {}).get("number", "?")
-        labels = _format_labels(page)
-        url = _page_url(page)
-
-        entry = (
-            f"{i}. **{page['title']}**\n"
-            f"   ID: {page['id']} | Space: {space_key} | v{version}"
-        )
-        if labels:
-            entry += f" | Labels: {labels}"
-        if url:
-            entry += f"\n   URL: {url}"
-        lines.append(entry)
-
-    return "\n\n".join(lines)
-
-
-@mcp.tool()
-async def get_page(
-    page_id: str,
-    format: Literal["storage", "view"] = "storage",
-    include_body: bool = True,
-) -> str:
-    """Retrieve a Confluence page's full content by its numeric ID.
-
-    Args:
-        page_id: The numeric page ID (e.g. '3965072').
-        format: Body format — 'storage' (raw XHTML, good for parsing)
-                or 'view' (rendered HTML, more readable).
-        include_body: Set False to fetch only metadata (title, space, labels).
-    """
-    expand_parts = ["version", "space", "metadata.labels", "ancestors"]
-    if include_body:
-        expand_parts.append(f"body.{format}")
-
-    try:
-        page = await client.get_page(page_id, expand=",".join(expand_parts))
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    space_name = page.get("space", {}).get("name", "")
-    space_key = page.get("space", {}).get("key", "")
-    version = page.get("version", {}).get("number", "")
-    labels = _format_labels(page)
-    ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
-    url = _page_url(page)
-
-    header = f"# {page['title']}\n"
-    header += f"Space: {space_name} ({space_key}) | Version: {version}\n"
-    if labels:
-        header += f"Labels: {labels}\n"
-    if ancestors:
-        header += f"Path: {ancestors} → {page['title']}\n"
-    if url:
-        header += f"URL: {url}\n"
-
-    if not include_body:
-        return header
-
-    raw_body = page.get("body", {}).get(format, {}).get("value", "")
-    body = _strip_html(raw_body) if format == "view" else raw_body
-    body = _truncate(body)
-
-    return f"{header}\n---\n\n{body}"
-
-
-@mcp.tool()
-async def get_page_by_title(
-    space_key: str,
-    title: str,
-) -> str:
-    """Find a Confluence page by its exact title within a space.
-
-    Args:
-        space_key: The space key (e.g. 'DEV', 'TEAM', 'HR').
-        title: The exact page title to look for.
-    """
-    try:
-        data = await client.get_page_by_title(
-            space_key=space_key,
-            title=title,
-            expand="body.storage,version,space,metadata.labels,ancestors",
-        )
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    results = data.get("results", [])
-    if not results:
-        return (
-            f"No page titled '{title}' found in space {space_key}.\n"
-            f"Tip: titles are case-sensitive and must be exact. "
-            f"Try search_confluence with: title~\"{title}\" AND space={space_key}"
-        )
-
-    page = results[0]
-    space_name = page.get("space", {}).get("name", "")
-    version = page.get("version", {}).get("number", "")
-    labels = _format_labels(page)
-    ancestors = " → ".join(a["title"] for a in page.get("ancestors", []))
-    url = _page_url(page)
-    raw_body = page.get("body", {}).get("storage", {}).get("value", "")
-
-    header = f"# {page['title']}\n"
-    header += f"ID: {page['id']} | Space: {space_name} ({space_key}) | Version: {version}\n"
-    if labels:
-        header += f"Labels: {labels}\n"
-    if ancestors:
-        header += f"Path: {ancestors} → {page['title']}\n"
-    if url:
-        header += f"URL: {url}\n"
-
-    return f"{header}\n---\n\n{_truncate(raw_body)}"
-
-
-@mcp.tool()
-async def list_spaces(
-    type: Literal["global", "personal", "all"] = "global",
-    limit: int = 50,
-) -> str:
-    """List Confluence spaces the authenticated user can access.
-
-    Args:
-        type: Filter by space type — 'global', 'personal', or 'all'.
-        limit: Maximum spaces to return (default 50).
-    """
-    try:
-        data = await client.list_spaces(
-            space_type=type if type != "all" else None,
-            limit=limit,
-            expand="description.plain",
-        )
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    spaces = data.get("results", [])
-    if not spaces:
-        return "No spaces found."
-
-    lines = [f"## Confluence Spaces ({len(spaces)} found)\n"]
-    for s in spaces:
-        desc = (
-            s.get("description", {})
-            .get("plain", {})
-            .get("value", "")
-            .strip()
-        )
-        desc_preview = (desc[:80] + "…") if len(desc) > 80 else desc
-        entry = f"- **{s['name']}** — key: `{s['key']}` ({s.get('type', '?')})"
-        if desc_preview:
-            entry += f"\n  {desc_preview}"
-        lines.append(entry)
-
-    return "\n".join(lines)
-
-
-@mcp.tool()
-async def get_comments(
-    page_id: str,
-    limit: int = 25,
-) -> str:
-    """Get comments on a Confluence page (including inline and footer comments).
-
-    Args:
-        page_id: The numeric page ID.
-        limit: Maximum comments to return (default 25).
-    """
-    try:
-        data = await client.get_child(
-            page_id=page_id,
-            child_type="comment",
-            expand="body.view,version,extensions.inlineProperties",
-            limit=limit,
-        )
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    comments = data.get("results", [])
-    if not comments:
-        return "No comments on this page."
-
-    lines = [f"## Comments ({len(comments)})\n"]
-    for c in comments:
-        author = (
-            c.get("version", {}).get("by", {}).get("displayName", "Unknown")
-        )
-        when = c.get("version", {}).get("when", "")
-        location = c.get("extensions", {}).get("location", "footer")
-        raw_body = c.get("body", {}).get("view", {}).get("value", "")
-        body = _strip_html(raw_body)
-
-        entry = f"**{author}** ({location})"
-        if when:
-            entry += f" — {when}"
-        entry += f"\n{body}"
-        lines.append(entry)
-
-    return "\n\n---\n\n".join(lines)
-
-
-@mcp.tool()
-async def get_attachments(
-    page_id: str,
-    limit: int = 50,
-) -> str:
-    """List file attachments on a Confluence page with download URLs.
-
-    Args:
-        page_id: The numeric page ID.
-        limit: Maximum attachments to return (default 50).
-    """
-    try:
-        data = await client.get_child(
-            page_id=page_id,
-            child_type="attachment",
-            expand="version",
-            limit=limit,
-        )
-    except ConfluenceError as e:
-        return _error_response(e)
-
-    atts = data.get("results", [])
-    if not atts:
-        return "No attachments on this page."
-
-    lines = [f"## Attachments ({len(atts)})\n"]
-    for a in atts:
-        media_type = a.get("metadata", {}).get("mediaType", "unknown")
-        download = a.get("_links", {}).get("download", "")
-        full_url = f"{config.confluence_url}{download}" if download else "N/A"
-        version = a.get("version", {}).get("number", "?")
-
-        lines.append(
-            f"- **{a['title']}**\n"
-            f"  Type: {media_type} | Version: {version}\n"
-            f"  Download: {full_url}"
-        )
-
-    return "\n".join(lines)
+# ── Register service tools (conditional on configuration) ────────
+
+if config.confluence.enabled:
+    from atlassian.confluence.client import ConfluenceClient
+    from atlassian.confluence.tools import register_tools as register_confluence
+
+    confluence_client = ConfluenceClient(config.confluence, config.deployment_type)
+    register_confluence(mcp, confluence_client, config)
+    logger.info("Confluence tools registered (URL: %s)", config.confluence.url)
+else:
+    logger.info("Confluence not configured — skipping")
+
+if config.jira.enabled:
+    from atlassian.jira.client import JiraClient
+    from atlassian.jira.tools import register_tools as register_jira
+
+    jira_client = JiraClient(config.jira, config.deployment_type)
+    register_jira(mcp, jira_client, config)
+    logger.info("Jira tools registered (URL: %s)", config.jira.url)
+else:
+    logger.info("Jira not configured — skipping")
+
+if config.bitbucket.enabled:
+    from atlassian.bitbucket.client import BitbucketClient
+    from atlassian.bitbucket.tools import register_tools as register_bitbucket
+
+    bitbucket_client = BitbucketClient(config.bitbucket, config.deployment_type)
+    register_bitbucket(mcp, bitbucket_client, config)
+    logger.info("Bitbucket tools registered (URL: %s)", config.bitbucket.url)
+else:
+    logger.info("Bitbucket not configured — skipping")
 
 
 # ── Entrypoint ──────────────────────────────────────────────────
 
 def main():
-    logger.info("Starting Confluence MCP Server")
-    logger.info("  URL:       %s", config.confluence_url)
-    logger.info("  Auth:      %s", config.auth_method)
+    enabled = []
+    if config.confluence.enabled:
+        enabled.append("Confluence")
+    if config.jira.enabled:
+        enabled.append("Jira")
+    if config.bitbucket.enabled:
+        enabled.append("Bitbucket")
+
+    logger.info("Starting Atlassian Enterprise MCP Server")
+    logger.info("  Services:  %s", ", ".join(enabled) or "none")
+    logger.info("  Deployment:%s", config.deployment_type)
     logger.info("  Transport: %s", config.transport)
 
     if config.transport == "http":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the Atlassian MCP Server."""

--- a/tests/test_base_client.py
+++ b/tests/test_base_client.py
@@ -1,0 +1,167 @@
+"""Unit tests for atlassian.base_client.BaseAtlassianClient."""
+
+import pytest
+import httpx
+import respx
+from atlassian.base_client import BaseAtlassianClient, AtlassianError
+
+
+def make_client(**kwargs) -> BaseAtlassianClient:
+    defaults = dict(
+        base_url="https://api.example.com",
+        token="test-token",
+        username=None,
+        password=None,
+        ssl_verify=True,
+        timeout=10,
+        rate_limit=10,
+    )
+    defaults.update(kwargs)
+    return BaseAtlassianClient(**defaults)
+
+
+@pytest.mark.asyncio
+class TestBaseClientGet:
+    @respx.mock
+    async def test_successful_get(self):
+        respx.get("https://api.example.com/items").mock(
+            return_value=httpx.Response(200, json={"items": [1, 2, 3]})
+        )
+        client = make_client()
+        result = await client.get("/items")
+        assert result == {"items": [1, 2, 3]}
+
+    @respx.mock
+    async def test_get_with_params(self):
+        route = respx.get("https://api.example.com/search").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        client = make_client()
+        await client.get("/search", {"q": "hello", "limit": 10})
+        assert route.called
+
+    @respx.mock
+    async def test_401_raises_atlassian_error(self):
+        respx.get("https://api.example.com/secure").mock(
+            return_value=httpx.Response(401, text="Unauthorized")
+        )
+        client = make_client()
+        with pytest.raises(AtlassianError) as exc_info:
+            await client.get("/secure")
+        assert exc_info.value.status_code == 401
+        assert "Authentication failed" in exc_info.value.message
+
+    @respx.mock
+    async def test_403_raises_atlassian_error(self):
+        respx.get("https://api.example.com/forbidden").mock(
+            return_value=httpx.Response(403, text="Forbidden")
+        )
+        client = make_client()
+        with pytest.raises(AtlassianError) as exc_info:
+            await client.get("/forbidden")
+        assert exc_info.value.status_code == 403
+
+    @respx.mock
+    async def test_404_raises_atlassian_error(self):
+        respx.get("https://api.example.com/missing").mock(
+            return_value=httpx.Response(404, text="Not Found")
+        )
+        client = make_client()
+        with pytest.raises(AtlassianError) as exc_info:
+            await client.get("/missing")
+        assert exc_info.value.status_code == 404
+
+    @respx.mock
+    async def test_500_raises_atlassian_error(self):
+        respx.get("https://api.example.com/error").mock(
+            return_value=httpx.Response(500, text="Internal Server Error")
+        )
+        client = make_client()
+        with pytest.raises(AtlassianError) as exc_info:
+            await client.get("/error")
+        assert exc_info.value.status_code == 500
+
+    @respx.mock
+    async def test_raw_mode_returns_text(self):
+        respx.get("https://api.example.com/diff").mock(
+            return_value=httpx.Response(200, text="--- a/file.py\n+++ b/file.py")
+        )
+        client = make_client()
+        result = await client.get("/diff", raw=True)
+        assert isinstance(result, str)
+        assert "--- a/file.py" in result
+
+    @respx.mock
+    async def test_bearer_token_in_header(self):
+        route = respx.get("https://api.example.com/me").mock(
+            return_value=httpx.Response(200, json={"name": "user"})
+        )
+        client = make_client(token="my-secret-token")
+        await client.get("/me")
+        assert route.called
+        request = route.calls[0].request
+        assert request.headers.get("authorization") == "Bearer my-secret-token"
+
+    @respx.mock
+    async def test_basic_auth_used_when_no_token(self):
+        route = respx.get("https://api.example.com/me").mock(
+            return_value=httpx.Response(200, json={"name": "user"})
+        )
+        client = make_client(token=None, username="user", password="pass")
+        await client.get("/me")
+        assert route.called
+        request = route.calls[0].request
+        assert "authorization" in request.headers
+        assert request.headers["authorization"].startswith("Basic ")
+
+
+@pytest.mark.asyncio
+class TestBaseClientPost:
+    @respx.mock
+    async def test_successful_post(self):
+        respx.post("https://api.example.com/issues").mock(
+            return_value=httpx.Response(201, json={"id": "1", "key": "PROJ-1"})
+        )
+        client = make_client()
+        result = await client.post("/issues", {"summary": "Test issue"})
+        assert result["key"] == "PROJ-1"
+
+    @respx.mock
+    async def test_post_204_returns_empty_dict(self):
+        respx.post("https://api.example.com/transition").mock(
+            return_value=httpx.Response(204)
+        )
+        client = make_client()
+        result = await client.post("/transition", {})
+        assert result == {}
+
+    @respx.mock
+    async def test_post_401_raises_error(self):
+        respx.post("https://api.example.com/issues").mock(
+            return_value=httpx.Response(401, text="Unauthorized")
+        )
+        client = make_client()
+        with pytest.raises(AtlassianError) as exc_info:
+            await client.post("/issues", {})
+        assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestBaseClientPut:
+    @respx.mock
+    async def test_successful_put(self):
+        respx.put("https://api.example.com/issue/PROJ-1").mock(
+            return_value=httpx.Response(204)
+        )
+        client = make_client()
+        result = await client.put("/issue/PROJ-1", {"fields": {"summary": "Updated"}})
+        assert result == {}
+
+    @respx.mock
+    async def test_put_with_response_body(self):
+        respx.put("https://api.example.com/issue/PROJ-1").mock(
+            return_value=httpx.Response(200, json={"id": "1", "key": "PROJ-1"})
+        )
+        client = make_client()
+        result = await client.put("/issue/PROJ-1", {})
+        assert result["key"] == "PROJ-1"

--- a/tests/test_bitbucket_client.py
+++ b/tests/test_bitbucket_client.py
@@ -1,0 +1,201 @@
+"""Unit tests for atlassian.bitbucket.client.BitbucketClient."""
+
+import pytest
+import httpx
+import respx
+from config import ServiceConfig
+from atlassian.bitbucket.client import BitbucketClient
+
+
+def make_service_config(**kwargs) -> ServiceConfig:
+    defaults = dict(
+        url="https://bitbucket.example.com",
+        token="test-token",
+        username=None,
+        password=None,
+        ssl_verify=True,
+        timeout=10,
+        rate_limit=10,
+        enabled=True,
+    )
+    defaults.update(kwargs)
+    return ServiceConfig(**defaults)
+
+
+class TestBitbucketClientUrls:
+    def test_datacenter_base_url(self):
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        assert client._base == "https://bitbucket.example.com/rest/api/1.0"
+
+    def test_cloud_base_url(self):
+        client = BitbucketClient(make_service_config(), deployment_type="cloud")
+        assert client._base == "https://api.bitbucket.org/2.0"
+
+    def test_is_cloud_property(self):
+        assert BitbucketClient(make_service_config(), deployment_type="cloud").is_cloud is True
+        assert BitbucketClient(make_service_config(), deployment_type="datacenter").is_cloud is False
+
+
+@pytest.mark.asyncio
+class TestBitbucketClientDatacenter:
+    @respx.mock
+    async def test_list_repos_datacenter(self):
+        respx.get("https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos").mock(
+            return_value=httpx.Response(200, json={"values": [{"slug": "my-repo", "name": "My Repo"}]})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.list_repos("PROJ", limit=25)
+        assert result["values"][0]["slug"] == "my-repo"
+
+    @respx.mock
+    async def test_get_repo_datacenter(self):
+        respx.get("https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo").mock(
+            return_value=httpx.Response(200, json={"slug": "my-repo", "name": "My Repo"})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.get_repo("PROJ", "my-repo")
+        assert result["slug"] == "my-repo"
+
+    @respx.mock
+    async def test_list_branches_datacenter(self):
+        respx.get(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/branches"
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"values": [{"displayId": "main", "latestCommit": "abc1234"}]}
+            )
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.list_branches("PROJ", "my-repo", limit=25)
+        assert result["values"][0]["displayId"] == "main"
+
+    @respx.mock
+    async def test_get_commits_datacenter(self):
+        respx.get(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/commits"
+        ).mock(
+            return_value=httpx.Response(
+                200, json={"values": [{"id": "abc1234", "message": "Initial commit"}]}
+            )
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.get_commits("PROJ", "my-repo")
+        assert result["values"][0]["id"] == "abc1234"
+
+    @respx.mock
+    async def test_list_pull_requests_datacenter(self):
+        respx.get(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests"
+        ).mock(
+            return_value=httpx.Response(200, json={"values": [{"id": 1, "title": "Add feature"}]})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.list_pull_requests("PROJ", "my-repo")
+        assert result["values"][0]["id"] == 1
+
+    @respx.mock
+    async def test_get_pull_request_datacenter(self):
+        respx.get(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/1"
+        ).mock(
+            return_value=httpx.Response(200, json={"id": 1, "title": "Add feature"})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.get_pull_request("PROJ", "my-repo", 1)
+        assert result["title"] == "Add feature"
+
+    @respx.mock
+    async def test_create_pull_request_datacenter(self):
+        route = respx.post(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests"
+        ).mock(
+            return_value=httpx.Response(
+                201, json={"id": 42, "title": "My PR", "links": {"self": [{"href": "http://..."}]}}
+            )
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.create_pull_request(
+            "PROJ", "my-repo", "My PR", "feature/foo", "main"
+        )
+        assert result["id"] == 42
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body["fromRef"]["id"] == "refs/heads/feature/foo"
+        assert body["toRef"]["id"] == "refs/heads/main"
+
+    @respx.mock
+    async def test_get_pr_diff_datacenter(self):
+        respx.get(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/1/diff"
+        ).mock(
+            return_value=httpx.Response(200, text="--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n+new line")
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.get_pr_diff("PROJ", "my-repo", 1)
+        assert isinstance(result, str)
+        assert "--- a/file.py" in result
+
+    @respx.mock
+    async def test_add_pr_comment_datacenter(self):
+        route = respx.post(
+            "https://bitbucket.example.com/rest/api/1.0/projects/PROJ/repos/my-repo/pull-requests/1/comments"
+        ).mock(
+            return_value=httpx.Response(201, json={"id": 10, "text": "LGTM"})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="datacenter")
+        result = await client.add_pr_comment("PROJ", "my-repo", 1, "LGTM")
+        assert result["id"] == 10
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body["text"] == "LGTM"
+
+
+@pytest.mark.asyncio
+class TestBitbucketClientCloud:
+    @respx.mock
+    async def test_list_repos_cloud(self):
+        respx.get("https://api.bitbucket.org/2.0/repositories/myworkspace").mock(
+            return_value=httpx.Response(
+                200, json={"values": [{"slug": "my-repo", "full_name": "myworkspace/my-repo"}]}
+            )
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="cloud")
+        result = await client.list_repos("myworkspace")
+        assert result["values"][0]["slug"] == "my-repo"
+
+    @respx.mock
+    async def test_create_pull_request_cloud(self):
+        route = respx.post(
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pullrequests"
+        ).mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": 5,
+                    "title": "My PR",
+                    "links": {"html": {"href": "https://bitbucket.org/..."}},
+                },
+            )
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="cloud")
+        result = await client.create_pull_request(
+            "myworkspace", "my-repo", "My PR", "feature/bar", "main"
+        )
+        assert result["id"] == 5
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body["source"]["branch"]["name"] == "feature/bar"
+        assert body["destination"]["branch"]["name"] == "main"
+
+    @respx.mock
+    async def test_add_pr_comment_cloud(self):
+        route = respx.post(
+            "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pullrequests/5/comments"
+        ).mock(
+            return_value=httpx.Response(201, json={"id": 99})
+        )
+        client = BitbucketClient(make_service_config(), deployment_type="cloud")
+        await client.add_pr_comment("myworkspace", "my-repo", 5, "Looks good!")
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body["content"]["raw"] == "Looks good!"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,205 @@
+"""Unit tests for config.py."""
+
+import os
+import pytest
+from unittest.mock import patch
+
+
+def _env(**kwargs):
+    """Return a minimal valid environment with overrides."""
+    base = {
+        "CONFLUENCE_URL": "https://wiki.example.com",
+        "CONFLUENCE_TOKEN": "mytoken",
+        "ATLASSIAN_DEPLOYMENT": "datacenter",
+        "MCP_TRANSPORT": "http",
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestLoadConfig:
+    def test_basic_confluence_only(self):
+        with patch.dict(os.environ, _env(), clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.enabled is True
+        assert config.confluence.url == "https://wiki.example.com"
+        assert config.confluence.token == "mytoken"
+        assert config.jira.enabled is False
+        assert config.bitbucket.enabled is False
+
+    def test_global_fallback_credentials(self):
+        env = {
+            "ATLASSIAN_URL": "https://myorg.atlassian.net",
+            "ATLASSIAN_TOKEN": "global_token",
+            "ATLASSIAN_DEPLOYMENT": "cloud",
+            "MCP_TRANSPORT": "http",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.url == "https://myorg.atlassian.net"
+        assert config.confluence.token == "global_token"
+        assert config.jira.url == "https://myorg.atlassian.net"
+        assert config.bitbucket.url == "https://myorg.atlassian.net"
+
+    def test_service_specific_overrides_global(self):
+        env = {
+            "ATLASSIAN_URL": "https://global.example.com",
+            "ATLASSIAN_TOKEN": "global_token",
+            "CONFLUENCE_URL": "https://wiki.example.com",
+            "CONFLUENCE_TOKEN": "conf_token",
+            "MCP_TRANSPORT": "http",
+            "ATLASSIAN_DEPLOYMENT": "datacenter",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.url == "https://wiki.example.com"
+        assert config.confluence.token == "conf_token"
+        assert config.jira.url == "https://global.example.com"
+        assert config.jira.token == "global_token"
+
+    def test_ssl_verify_false(self):
+        env = _env(**{"CONFLUENCE_SSL_VERIFY": "false"})
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.ssl_verify is False
+
+    def test_ssl_verify_ca_bundle(self):
+        env = _env(**{"CONFLUENCE_CA_BUNDLE": "/etc/ssl/certs/ca.pem"})
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.ssl_verify == "/etc/ssl/certs/ca.pem"
+
+    def test_deployment_type_cloud(self):
+        env = _env(**{"ATLASSIAN_DEPLOYMENT": "cloud"})
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.deployment_type == "cloud"
+
+    def test_trailing_slash_stripped(self):
+        env = _env(**{"CONFLUENCE_URL": "https://wiki.example.com/"})
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert not config.confluence.url.endswith("/")
+
+    def test_timeout_and_rate_limit_parsed(self):
+        env = _env(**{"CONFLUENCE_TIMEOUT": "60", "CONFLUENCE_RATE_LIMIT": "10"})
+        with patch.dict(os.environ, env, clear=True):
+            from importlib import reload
+            import config as cfg_module
+            reload(cfg_module)
+            config = cfg_module.load_config()
+
+        assert config.confluence.timeout == 60
+        assert config.confluence.rate_limit == 10
+
+
+class TestAtlassianConfigValidate:
+    def _make_service(self, **kwargs):
+        from config import ServiceConfig
+        defaults = {
+            "url": "https://example.com",
+            "token": "tok",
+            "username": None,
+            "password": None,
+            "ssl_verify": True,
+            "timeout": 30,
+            "rate_limit": 5,
+            "enabled": True,
+        }
+        defaults.update(kwargs)
+        return ServiceConfig(**defaults)
+
+    def _make_config(self, **kwargs):
+        from config import AtlassianConfig, ServiceConfig
+        disabled_svc = ServiceConfig(
+            url="", token=None, username=None, password=None,
+            ssl_verify=True, timeout=30, rate_limit=5, enabled=False,
+        )
+        defaults = dict(
+            deployment_type="datacenter",
+            confluence=self._make_service(),
+            jira=disabled_svc,
+            bitbucket=disabled_svc,
+            transport="http",
+            host="0.0.0.0",
+            port=8000,
+            max_content_length=50000,
+            default_search_limit=10,
+            log_level="INFO",
+        )
+        defaults.update(kwargs)
+        return AtlassianConfig(**defaults)
+
+    def test_valid_config_no_errors(self):
+        config = self._make_config()
+        assert config.validate() == []
+
+    def test_invalid_deployment_type(self):
+        config = self._make_config(deployment_type="on-prem")
+        errors = config.validate()
+        assert any("ATLASSIAN_DEPLOYMENT" in e for e in errors)
+
+    def test_invalid_transport(self):
+        config = self._make_config(transport="grpc")
+        errors = config.validate()
+        assert any("MCP_TRANSPORT" in e for e in errors)
+
+    def test_no_services_enabled(self):
+        from config import ServiceConfig
+        disabled_svc = ServiceConfig(
+            url="", token=None, username=None, password=None,
+            ssl_verify=True, timeout=30, rate_limit=5, enabled=False,
+        )
+        config = self._make_config(confluence=disabled_svc, jira=disabled_svc, bitbucket=disabled_svc)
+        errors = config.validate()
+        assert any("No services" in e for e in errors)
+
+    def test_service_without_credentials(self):
+        from config import ServiceConfig
+        no_creds_svc = ServiceConfig(
+            url="https://example.com", token=None, username=None, password=None,
+            ssl_verify=True, timeout=30, rate_limit=5, enabled=True,
+        )
+        config = self._make_config(confluence=no_creds_svc)
+        errors = config.validate()
+        assert any("Confluence" in e for e in errors)
+
+    def test_auth_method_token(self):
+        svc = self._make_service(token="mytoken")
+        assert svc.auth_method == "token"
+
+    def test_auth_method_basic(self):
+        svc = self._make_service(token=None, username="user", password="pass")
+        assert svc.auth_method == "basic"
+
+    def test_auth_method_none(self):
+        svc = self._make_service(token=None, username=None, password=None)
+        assert svc.auth_method == "none"

--- a/tests/test_confluence_client.py
+++ b/tests/test_confluence_client.py
@@ -1,0 +1,94 @@
+"""Unit tests for atlassian.confluence.client.ConfluenceClient."""
+
+import pytest
+import httpx
+import respx
+from config import ServiceConfig
+from atlassian.confluence.client import ConfluenceClient
+
+
+def make_service_config(**kwargs) -> ServiceConfig:
+    defaults = dict(
+        url="https://wiki.example.com",
+        token="test-token",
+        username=None,
+        password=None,
+        ssl_verify=True,
+        timeout=10,
+        rate_limit=10,
+        enabled=True,
+    )
+    defaults.update(kwargs)
+    return ServiceConfig(**defaults)
+
+
+class TestConfluenceClientUrls:
+    def test_datacenter_base_url(self):
+        client = ConfluenceClient(make_service_config(), deployment_type="datacenter")
+        assert client._base == "https://wiki.example.com/rest/api"
+
+    def test_cloud_base_url(self):
+        client = ConfluenceClient(make_service_config(), deployment_type="cloud")
+        assert client._base == "https://wiki.example.com/wiki/rest/api"
+
+
+@pytest.mark.asyncio
+class TestConfluenceClientMethods:
+    @respx.mock
+    async def test_get_page(self):
+        respx.get("https://wiki.example.com/rest/api/content/123").mock(
+            return_value=httpx.Response(200, json={"id": "123", "title": "My Page"})
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.get_page("123", expand="body.storage")
+        assert result["id"] == "123"
+        assert result["title"] == "My Page"
+
+    @respx.mock
+    async def test_get_page_by_title(self):
+        respx.get("https://wiki.example.com/rest/api/content").mock(
+            return_value=httpx.Response(200, json={"results": [{"id": "456", "title": "Hello"}]})
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.get_page_by_title("DEV", "Hello", expand="body.storage")
+        assert result["results"][0]["id"] == "456"
+
+    @respx.mock
+    async def test_search(self):
+        respx.get("https://wiki.example.com/rest/api/content/search").mock(
+            return_value=httpx.Response(
+                200, json={"results": [{"id": "789", "title": "Result"}], "totalSize": 1}
+            )
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.search("type=page AND text~'hello'", limit=10, expand="space")
+        assert len(result["results"]) == 1
+
+    @respx.mock
+    async def test_list_spaces(self):
+        respx.get("https://wiki.example.com/rest/api/space").mock(
+            return_value=httpx.Response(
+                200, json={"results": [{"key": "DEV", "name": "Development"}]}
+            )
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.list_spaces(space_type="global", limit=50, expand="description.plain")
+        assert result["results"][0]["key"] == "DEV"
+
+    @respx.mock
+    async def test_get_child_comments(self):
+        respx.get("https://wiki.example.com/rest/api/content/123/child/comment").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.get_child("123", "comment", expand="body.view", limit=25)
+        assert result["results"] == []
+
+    @respx.mock
+    async def test_get_labels(self):
+        respx.get("https://wiki.example.com/rest/api/content/123/label").mock(
+            return_value=httpx.Response(200, json={"results": [{"name": "api"}]})
+        )
+        client = ConfluenceClient(make_service_config())
+        result = await client.get_labels("123")
+        assert result["results"][0]["name"] == "api"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,0 +1,137 @@
+"""Unit tests for atlassian.shared.formatters."""
+
+import pytest
+from atlassian.shared.formatters import strip_html, truncate, adf_to_text
+
+
+class TestStripHtml:
+    def test_removes_tags(self):
+        assert strip_html("<p>Hello</p>") == "Hello"
+
+    def test_br_becomes_newline(self):
+        result = strip_html("line1<br/>line2")
+        assert "line1" in result
+        assert "line2" in result
+        assert "\n" in result
+
+    def test_block_elements_add_newline(self):
+        result = strip_html("<p>Para 1</p><p>Para 2</p>")
+        assert "Para 1" in result
+        assert "Para 2" in result
+
+    def test_decodes_html_entities(self):
+        assert "&amp;" not in strip_html("a &amp; b")
+        assert "&nbsp;" not in strip_html("a&nbsp;b")
+        assert "&lt;" not in strip_html("a &lt; b")
+        assert "&gt;" not in strip_html("a &gt; b")
+
+    def test_collapses_excess_newlines(self):
+        result = strip_html("<p>a</p><p>b</p><p>c</p>")
+        assert "\n\n\n" not in result
+
+    def test_strips_nested_tags(self):
+        result = strip_html("<div><span><b>Bold</b></span></div>")
+        assert result == "Bold"
+
+    def test_empty_string(self):
+        assert strip_html("") == ""
+
+    def test_plain_text_unchanged(self):
+        assert strip_html("hello world") == "hello world"
+
+    def test_heading_tags(self):
+        result = strip_html("<h1>Title</h1><p>Body</p>")
+        assert "Title" in result
+        assert "Body" in result
+
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        text = "hello"
+        assert truncate(text, 100) == text
+
+    def test_exact_length_unchanged(self):
+        text = "a" * 100
+        assert truncate(text, 100) == text
+
+    def test_long_text_truncated(self):
+        text = "a" * 200
+        result = truncate(text, 100)
+        assert len(result) > 100  # includes the truncation message
+        assert "truncated" in result
+        assert "200 chars" in result
+
+    def test_truncation_preserves_start(self):
+        text = "hello" + "x" * 200
+        result = truncate(text, 10)
+        assert result.startswith("hello")
+
+    def test_default_max_len(self):
+        text = "a" * 49999
+        assert truncate(text) == text  # under default 50000
+
+    def test_default_max_len_exceeded(self):
+        text = "a" * 60000
+        result = truncate(text)
+        assert "truncated" in result
+
+
+class TestAdfToText:
+    def test_simple_paragraph(self):
+        adf = {
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Hello world"}],
+                }
+            ],
+        }
+        result = adf_to_text(adf)
+        assert "Hello world" in result
+
+    def test_bullet_list(self):
+        adf = {
+            "type": "bulletList",
+            "content": [
+                {
+                    "type": "listItem",
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Item 1"}],
+                        }
+                    ],
+                },
+                {
+                    "type": "listItem",
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": "Item 2"}],
+                        }
+                    ],
+                },
+            ],
+        }
+        result = adf_to_text(adf)
+        assert "Item 1" in result
+        assert "Item 2" in result
+
+    def test_non_dict_returns_str(self):
+        assert adf_to_text("plain text") == "plain text"
+
+    def test_code_block(self):
+        adf = {
+            "type": "codeBlock",
+            "content": [{"type": "text", "text": "print('hello')"}],
+        }
+        result = adf_to_text(adf)
+        assert "print('hello')" in result
+        assert "```" in result
+
+    def test_empty_doc(self):
+        adf = {"type": "doc", "version": 1, "content": []}
+        result = adf_to_text(adf)
+        assert result == ""

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -1,0 +1,193 @@
+"""Unit tests for atlassian.jira.client.JiraClient."""
+
+import pytest
+import httpx
+import respx
+from config import ServiceConfig
+from atlassian.jira.client import JiraClient
+
+
+def make_service_config(**kwargs) -> ServiceConfig:
+    defaults = dict(
+        url="https://jira.example.com",
+        token="test-token",
+        username=None,
+        password=None,
+        ssl_verify=True,
+        timeout=10,
+        rate_limit=10,
+        enabled=True,
+    )
+    defaults.update(kwargs)
+    return ServiceConfig(**defaults)
+
+
+class TestJiraClientUrls:
+    def test_datacenter_uses_api_v2(self):
+        client = JiraClient(make_service_config(), deployment_type="datacenter")
+        assert client._base == "https://jira.example.com/rest/api/2"
+
+    def test_cloud_uses_api_v3(self):
+        client = JiraClient(make_service_config(), deployment_type="cloud")
+        assert client._base == "https://jira.example.com/rest/api/3"
+
+    def test_is_cloud_property(self):
+        assert JiraClient(make_service_config(), deployment_type="cloud").is_cloud is True
+        assert JiraClient(make_service_config(), deployment_type="datacenter").is_cloud is False
+
+
+class TestJiraDescriptionBody:
+    def test_datacenter_returns_plain_string(self):
+        client = JiraClient(make_service_config(), deployment_type="datacenter")
+        result = client._description_body("My description")
+        assert result == "My description"
+
+    def test_cloud_returns_adf(self):
+        client = JiraClient(make_service_config(), deployment_type="cloud")
+        result = client._description_body("My description")
+        assert isinstance(result, dict)
+        assert result["type"] == "doc"
+        assert result["version"] == 1
+        content = result["content"][0]
+        assert content["type"] == "paragraph"
+        assert content["content"][0]["text"] == "My description"
+
+
+@pytest.mark.asyncio
+class TestJiraClientMethods:
+    @respx.mock
+    async def test_get_issue(self):
+        respx.get("https://jira.example.com/rest/api/2/issue/PROJ-1").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "key": "PROJ-1",
+                    "fields": {"summary": "Test issue", "status": {"name": "Open"}},
+                },
+            )
+        )
+        client = JiraClient(make_service_config())
+        result = await client.get_issue("PROJ-1")
+        assert result["key"] == "PROJ-1"
+
+    @respx.mock
+    async def test_search_issues(self):
+        respx.get("https://jira.example.com/rest/api/2/search").mock(
+            return_value=httpx.Response(
+                200, json={"issues": [{"key": "PROJ-1"}], "total": 1}
+            )
+        )
+        client = JiraClient(make_service_config())
+        result = await client.search_issues("project = PROJ")
+        assert len(result["issues"]) == 1
+
+    @respx.mock
+    async def test_create_issue(self):
+        respx.post("https://jira.example.com/rest/api/2/issue").mock(
+            return_value=httpx.Response(201, json={"id": "10001", "key": "PROJ-2"})
+        )
+        client = JiraClient(make_service_config())
+        result = await client.create_issue("PROJ", "New Issue", "Task", "A description")
+        assert result["key"] == "PROJ-2"
+
+    @respx.mock
+    async def test_create_issue_cloud_uses_adf(self):
+        route = respx.post("https://jira.example.com/rest/api/3/issue").mock(
+            return_value=httpx.Response(201, json={"id": "10001", "key": "PROJ-3"})
+        )
+        client = JiraClient(make_service_config(), deployment_type="cloud")
+        await client.create_issue("PROJ", "New Issue", "Task", "Some description")
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert isinstance(body["fields"]["description"], dict)
+        assert body["fields"]["description"]["type"] == "doc"
+
+    @respx.mock
+    async def test_update_issue(self):
+        respx.put("https://jira.example.com/rest/api/2/issue/PROJ-1").mock(
+            return_value=httpx.Response(204)
+        )
+        client = JiraClient(make_service_config())
+        result = await client.update_issue("PROJ-1", summary="Updated Summary")
+        assert result == {}
+
+    @respx.mock
+    async def test_get_transitions(self):
+        respx.get("https://jira.example.com/rest/api/2/issue/PROJ-1/transitions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "transitions": [
+                        {"id": "11", "name": "Start Progress", "to": {"name": "In Progress"}},
+                        {"id": "21", "name": "Done", "to": {"name": "Done"}},
+                    ]
+                },
+            )
+        )
+        client = JiraClient(make_service_config())
+        result = await client.get_transitions("PROJ-1")
+        assert len(result["transitions"]) == 2
+
+    @respx.mock
+    async def test_transition_issue(self):
+        respx.post("https://jira.example.com/rest/api/2/issue/PROJ-1/transitions").mock(
+            return_value=httpx.Response(204)
+        )
+        client = JiraClient(make_service_config())
+        result = await client.transition_issue("PROJ-1", "21")
+        assert result == {}
+
+    @respx.mock
+    async def test_add_comment_datacenter(self):
+        respx.post("https://jira.example.com/rest/api/2/issue/PROJ-1/comment").mock(
+            return_value=httpx.Response(201, json={"id": "10100", "body": "Test comment"})
+        )
+        client = JiraClient(make_service_config(), deployment_type="datacenter")
+        result = await client.add_comment("PROJ-1", "Test comment")
+        assert result["id"] == "10100"
+
+    @respx.mock
+    async def test_list_projects(self):
+        respx.get("https://jira.example.com/rest/api/2/project/search").mock(
+            return_value=httpx.Response(
+                200,
+                json={"values": [{"key": "PROJ", "name": "My Project"}], "total": 1},
+            )
+        )
+        client = JiraClient(make_service_config())
+        result = await client.list_projects()
+        assert result["values"][0]["key"] == "PROJ"
+
+    @respx.mock
+    async def test_get_project(self):
+        respx.get("https://jira.example.com/rest/api/2/project/PROJ").mock(
+            return_value=httpx.Response(
+                200,
+                json={"key": "PROJ", "name": "My Project", "issueTypes": []},
+            )
+        )
+        client = JiraClient(make_service_config())
+        result = await client.get_project("PROJ")
+        assert result["key"] == "PROJ"
+
+    @respx.mock
+    async def test_assign_issue_cloud(self):
+        route = respx.put("https://jira.example.com/rest/api/3/issue/PROJ-1/assignee").mock(
+            return_value=httpx.Response(204)
+        )
+        client = JiraClient(make_service_config(), deployment_type="cloud")
+        await client.assign_issue("PROJ-1", "account123")
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body.get("accountId") == "account123"
+
+    @respx.mock
+    async def test_assign_issue_datacenter(self):
+        route = respx.put("https://jira.example.com/rest/api/2/issue/PROJ-1/assignee").mock(
+            return_value=httpx.Response(204)
+        )
+        client = JiraClient(make_service_config(), deployment_type="datacenter")
+        await client.assign_issue("PROJ-1", "jsmith")
+        import json
+        body = json.loads(route.calls[0].request.content)
+        assert body.get("name") == "jsmith"

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -1,0 +1,72 @@
+"""Unit tests for atlassian.shared.url_utils."""
+
+import pytest
+from atlassian.shared.url_utils import parse_confluence_url
+
+
+class TestParseConfluenceUrl:
+    def test_page_id_query_param(self):
+        result = parse_confluence_url("http://wiki.example.com/pages/viewpage.action?pageId=12345")
+        assert result["page_id"] == "12345"
+        assert result["space_key"] is None
+        assert result["title"] is None
+
+    def test_display_format(self):
+        result = parse_confluence_url("http://wiki.example.com/display/DEV/My+Page+Title")
+        assert result["space_key"] == "DEV"
+        assert result["title"] == "My Page Title"
+        assert result["page_id"] is None
+
+    def test_display_format_with_query(self):
+        result = parse_confluence_url(
+            "http://wiki.example.com/display/DEV/Page?src=contextnavpagetreemode"
+        )
+        assert result["space_key"] == "DEV"
+        assert result["title"] == "Page"
+
+    def test_spaces_format(self):
+        result = parse_confluence_url(
+            "http://wiki.example.com/spaces/DEV/pages/99999/Some+Title"
+        )
+        assert result["space_key"] == "DEV"
+        assert result["page_id"] == "99999"
+        assert result["title"] == "Some Title"
+
+    def test_wiki_prefix_stripped(self):
+        result = parse_confluence_url(
+            "http://mycompany.atlassian.net/wiki/display/ENG/Architecture"
+        )
+        assert result["space_key"] == "ENG"
+        assert result["title"] == "Architecture"
+
+    def test_confluence_prefix_stripped(self):
+        result = parse_confluence_url(
+            "http://wiki.example.com/confluence/display/HR/Onboarding"
+        )
+        assert result["space_key"] == "HR"
+        assert result["title"] == "Onboarding"
+
+    def test_tiny_url(self):
+        result = parse_confluence_url("http://wiki.example.com/x/AbCd")
+        assert result["page_id"] is not None
+        assert result["page_id"].startswith("tinyurl:")
+
+    def test_direct_page_id(self):
+        result = parse_confluence_url("http://wiki.example.com/pages/98765")
+        assert result["page_id"] == "98765"
+
+    def test_encoded_title(self):
+        result = parse_confluence_url(
+            "http://wiki.example.com/display/SPACE/My%20Encoded%20Title"
+        )
+        assert result["title"] == "My Encoded Title"
+
+    def test_unrecognized_url_returns_none(self):
+        result = parse_confluence_url("http://wiki.example.com/unknown/path")
+        assert result["page_id"] is None
+        assert result["space_key"] is None
+        assert result["title"] is None
+
+    def test_numeric_fallback(self):
+        result = parse_confluence_url("http://wiki.example.com/some/path/12345/rest")
+        assert result["page_id"] == "12345"


### PR DESCRIPTION
- Introduce atlassian/ package with BaseAtlassianClient (auth, retry, rate-limiting)
- Refactor config.py to AtlassianConfig/ServiceConfig with per-service and
  global credential fallback; backward-compatible with existing CONFLUENCE_* vars
- Add Confluence tools module (7 tools, prefixed confluence_*)
- Add Jira client + 12 tools (jira_get_issue, jira_search_issues, jira_create_issue,
  jira_update_issue, jira_transition_issue, jira_get_transitions, jira_add_comment,
  jira_get_comments, jira_list_projects, jira_get_project, jira_assign_issue,
  jira_get_my_issues) with Cloud (ADF/API v3) and Data Center (API v2) support
- Add Bitbucket client + 10 tools (list_repos, get_repo, list_branches, get_commits,
  get_commit, list_pull_requests, get_pull_request, create_pull_request,
  get_pr_diff, add_pr_comment) with Cloud and Data Center support
- Refactor server.py to conditionally register tools per enabled service
- Add shared formatters (strip_html, truncate, adf_to_text) and url_utils
- Add 101 unit tests covering all clients, config, formatters, and URL parsing
- Add requirements-dev.txt, pytest.ini, and .env.example
- Update Dockerfile and docker-compose.yml for the new module structure

https://claude.ai/code/session_01GPkVB9dvXRhmaeNrU8nTCZ